### PR TITLE
Add python path to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The following dependencies are needed in order to run Koop on your local machine
 
 
 ## Installation
+1. Setup the Python environmental variable
+2. 
+    ```
+    # Windows
+    SET PYTHON = C:\Python27\python\python.exe
+    
+    ```
 
 1. Clone the repo
 


### PR DESCRIPTION
Good Morning,

I tried installing koop but received an error about not having a python system variable.  I'm not sure if this is just windows, but you might want to add it to the Readme.
