### PR TITLE
add gh-release to dev dependencies & scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/models/ -t 20000",
-    "lint": "gulp"
+    "lint": "gulp",
+    "release": "gh-release"
   },
   "author": {
     "name": "Chris Helm"
@@ -43,6 +44,7 @@
     "url": "https://github.com/Esri/koop/issues"
   },
   "devDependencies": {
+    "gh-release": "^1.1.6",
     "gulp": "^3.8.11",
     "gulp-escomplex": "^1.0.1",
     "gulp-escomplex-reporter-html": "^1.0.0",


### PR DESCRIPTION
This automates another part of the release workflow.

This is intended to be run before `npm publish`, as it's also a safe method of auditing what you're about to publish. You can edit/delete github releases and tags pretty easily, but once something's published to npm it's a lot harder to undo.

Can be run with `npm run release` (no global install of gh-release required).
