### PR TITLE
Exporter fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+* Parsing the logpath in `lib/Logger` needed to use slice instead of splice
+
+### Added
+* Tests for new method `lib/Exporter.js:createIdFilter` 
 
 ### Changed
 * refactored preview to incorporate breaking changes in esri-leaflet 1.0.0
@@ -11,9 +16,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 * Leaflet image files
-
-### Fixed
-* Parsing the logpath in `lib/Logger` needed to use slice instead of splice
 
 ## [2.5.3] - 2015-07-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * refactored preview to incorporate breaking changes in esri-leaflet 1.0.0
 * switched to using L.Icon.Default
+* refactored the idFilter logic into a shared method in Exporter `createIdFilter`
 
 ### Removed
 * Leaflet image files

--- a/lib/ExportWorker.js
+++ b/lib/ExportWorker.js
@@ -198,6 +198,9 @@ function createFiles (job, done) {
 
   var workerQ = async.queue(function (task, cb) {
 
+    // make sure offset is in options for creating the idFilter below
+    task.options.offset = task.offset
+
     var opts = {
       layer: task.options.layer,
       where: task.options.where,

--- a/lib/ExportWorker.js
+++ b/lib/ExportWorker.js
@@ -1,7 +1,7 @@
 var kue = require('kue')
 var fs = require('node-fs')
 var async = require('async')
-var koopLib = require('.')
+var koopLib = require('./')
 var pgcache = require('koop-pgcache')
 var path = require('path')
 var rimraf = require('rimraf')
@@ -197,17 +197,11 @@ function createFiles (job, done) {
   fs.appendFileSync(job.data.files.rootVrtFile, vrt)
 
   var workerQ = async.queue(function (task, cb) {
-    var idFilter
-
-    if (task.offset) {
-      idFilter = ' id >= ' + task.offset + ' AND id < ' +
-        parseInt(task.offset, 10) + parseInt(task.options.limit, 10)
-    }
 
     var opts = {
       layer: task.options.layer,
       where: task.options.where,
-      idFilter: idFilter,
+      idFilter: koopLib.Exporter.createIdFilter(task.options),
       geometry: task.options.geometry,
       bypassProcessing: true
     }

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -26,6 +26,23 @@ var shapefileParts = [
   'shp.xml'
 ]
 
+/**
+ * Creates filter based on row ids
+ * Since ids are handled differently in the Caches (not feature proprties but table props instead)
+ * its more effencient to page over large tables using row ids than feature.property.objectIds
+ *
+ * @param {object} options
+ * @returns {string} idFilter
+ */
+function createIdFilter (options) {
+  var idFilter
+  if (options && options.offset && options.limit) {
+    idFilter = ' id >= ' + options.offset + ' AND id < ' +
+      (parseInt(options.offset, 10) + parseInt(options.limit, 10))
+  }
+  return idFilter
+}
+
 // exports large data via multi part file strategy
 exports.exportLarge = function (koop, format, id, key, type, options, finish, done) {
   // exports large data via multi part file strategy
@@ -108,17 +125,8 @@ exports.exportLarge = function (koop, format, id, key, type, options, finish, do
   }
 
   var q = async.queue(function (task, cb) {
-    // instead of passing a limit and offset
-    // we use a WHERE clause
-    var idFilter
-
-    if (options.offset) {
-      idFilter = ' id >= ' + options.offset + ' AND id < ' +
-        parseInt(options.offset, 10) + parseInt(options.limit, 10)
-    }
-
     var opts = {
-      idFilter: idFilter,
+      idFilter: createIdFilter(options),
       layer: options.layer,
       where: options.where,
       geometry: options.geometry,
@@ -526,6 +534,7 @@ function getOgrParams (format, inFile, outFile, geojson, options) {
   return cmd.join(' ')
 }
 
+exports.createIdFilter = createIdFilter
 exports.createPaths = createPaths
 exports.callOgr = callOgr
 exports.moveFile = moveFile

--- a/test/models/exporter-test.js
+++ b/test/models/exporter-test.js
@@ -33,6 +33,29 @@ describe('exporter Model', function () {
     })
   })
 
+  describe('when creating id filters', function () {
+    it('should create a correct idFilter if given an offset and limit', function (done) {
+      var options = {
+        offset: '1000',
+        limit: 10
+      }
+
+      var filter = exporter.createIdFilter(options)
+      filter.should.equal(' id >= 1000 AND id < 1010')
+      done()
+    })
+
+    it('should return an undefined id filter if given no limit', function (done) {
+      var options = {
+        offset: '1000'
+      }
+
+      var filter = exporter.createIdFilter(options)
+      should.not.exist(filter)
+      done()
+    })
+  })
+
   describe('when creating paths for exports', function () {
     it('should return an object with files and paths', function (done) {
       var format = 'csv'


### PR DESCRIPTION
Some issues with lib/* refactor cropped up in the ExportWorker. It was mostly an issue with creating the idFilter that gets used when paging over the Cache while exporting data. I fixed the issues and added a test around the logic for creating the idFilter. 