### PR TITLE
minor log improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * reorganized index for readability & code organization
 * throw error on bad provider or cache registration
 * consolidated koop, lib, app ([#237](https://github.com/koopjs/koop/issues/237))
+* logging version and mountpath when express middleware is mounted
 
 ### Added
 * `app.registerProvider` method for providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * `lib/Files` now takes `options` instead of `koop` (only needed koop.config and koop.log)
 * cleaned up `app.register` method logic
+  * `app.register` can now register caches and plugins if `type` is specified correctly
+  * delegates to `app.registerProvider`, `app.registerCache`, `app.registerPlugin`
+  * throws error on bad provider or cache registration
 * using `koop.log` in index instead of `console.log`
 * reorganized index for readability & code organization
-* throw error on bad provider or cache registration
 * consolidated koop, lib, app ([#237](https://github.com/koopjs/koop/issues/237))
 * logging version and mountpath when express middleware is mounted
 

--- a/index.js
+++ b/index.js
@@ -327,5 +327,9 @@ module.exports = function (config) {
     })
   }
 
+  koop.on('mount', function (parent) {
+    koop.log.info('Koop %s mounted at %s', koop.version, koop.mountpath)
+  })
+
   return koop
 }

--- a/index.js
+++ b/index.js
@@ -29,8 +29,15 @@ module.exports = function (config) {
   koop.Cache = new koop.DataCache()
   koop.Cache.db = koop.LocalDB
 
-  if (!koop.config.db || !koop.config.db.conn) {
-    koop.log.warn('No cache configured, defaulting to local in-memory cache. No data will be cached across server sessions.')
+  // object for keeping track of registered services
+  // TODO: why not called providers?
+  // if services includes caches and plugins we should put them in here too
+  koop.services = {}
+
+  // TODO: consolidate status, services, `/providers` routes
+  koop.status = {
+    version: koop.version,
+    providers: {}
   }
 
   // expose default routes for later additions & edits by plugins
@@ -38,6 +45,10 @@ module.exports = function (config) {
     'featureserver': ['/FeatureServer/:layer/:method', '/FeatureServer/:layer', '/FeatureServer'],
     'preview': ['/preview'],
     'drop': ['/drop']
+  }
+
+  if (!koop.config.db || !koop.config.db.conn) {
+    koop.log.warn('No cache configured, defaulting to local in-memory cache. No data will be cached across server sessions.')
   }
 
   /**
@@ -63,17 +74,6 @@ module.exports = function (config) {
   // for demos and preview maps in providers
   koop.set('view engine', 'ejs')
   koop.use(express.static(__dirname + '/public'))
-
-  // object for keeping track of registered services
-  // TODO: why not called providers?
-  // if services includes caches and plugins we should put them in here too
-  koop.services = {}
-
-  // TODO: consolidate status, services, `/providers` routes
-  koop.status = {
-    version: koop.version,
-    providers: {}
-  }
 
   /**
    * public methods
@@ -115,6 +115,8 @@ module.exports = function (config) {
     provider.version = provider.version || '(version missing)'
 
     // if a provider has a status object store it
+    // TODO: deprecate, move version to root of object.
+    //       we should serve more meaningful status reports dynamically.
     if (provider.status) {
       koop.status.providers[provider.name] = provider.status
       provider.version = provider.status.version

--- a/index.js
+++ b/index.js
@@ -115,8 +115,7 @@ module.exports = function (config) {
     provider.version = provider.version || '(version missing)'
 
     // if a provider has a status object store it
-    // TODO: deprecate, move version to root of object.
-    //       we should serve more meaningful status reports dynamically.
+    // TODO: deprecate & serve more meaningful status reports dynamically.
     if (provider.status) {
       koop.status.providers[provider.name] = provider.status
       provider.version = provider.status.version

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function (config) {
       return koop.registerProvider(plugin)
     }
 
-    koop.log.warn('Plugin missing type property. Defaulting to provider.')
+    koop.log.warn('Plugin "%s" missing type property. Defaulting to provider.', plugin.name)
     koop.registerProvider(plugin)
   }
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (config) {
     if (lib.hasOwnProperty(method)) koop[method] = lib[method]
   }
 
+  koop.version = pkg.version
   koop.config = config || {}
   koop.log = new koop.Logger(koop.config)
   koop.files = new koop.Files({
@@ -70,7 +71,7 @@ module.exports = function (config) {
 
   // TODO: consolidate status, services, `/providers` routes
   koop.status = {
-    version: pkg.version,
+    version: koop.version,
     providers: {}
   }
 


### PR DESCRIPTION
This will give us more of a clue of what's going on when Koop gets initialized.

Logs Koop version and mountpath when `app.use(koop)` gets called in an express app.

Makes "missing type property" warning more informative.

So now we see some useful info on startup:

```
info: registered cache: postgis 1.1.0
warn: Plugin "Gist" missing type property. Defaulting to provider.
warn: No Github token in config for Gist provider. This may cause problems accessing data.
info: registered provider: Gist 1.0.1
info: Koop 2.6.2 mounted at /
```