### PR TITLE
Use DB sorting instead of in-memory sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * refactor `lib/Query` (no more `this`)
 * add jsdoc to BaseModel, FeatureServices, Query
+* does sorting in the DB where available
 
 ## [2.7.0] - 2015-09-02
 ### Changed

--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -115,7 +115,7 @@ function Cache () {
 
   /**
    * Get features from the DB
-   * calls the "select" methon on the DB
+   * calls the "select" method on the DB
    * TODO make this use a table name instead of "type" and "key"
    *
    * @param {string} type - the provider type, used for setting provider based timers etc
@@ -126,10 +126,43 @@ function Cache () {
   this.get = function (type, key, options, callback) {
     var self = this
     var table = type + ':' + key
-    this.db.select(table, options, function (err, result) {
+    var query = this.decodeGeoservices(options)
+    this.db.select(table, query, function (err, result) {
       if (err) return callback(err)
       self.process(type, key, result, options, callback)
     })
+  }
+
+  /**
+   * Translates a geoservices query into sql parts
+   *
+   * @param {object} query - an object with geoservices strings
+   * @return {object} parsed sql parts
+   */
+  this.decodeGeoservices = function (query) {
+    if (query.orderByFields && query.orderByFields.length) {
+      query.order_by = this._convertOrderByFields(query.orderByFields)
+      delete query.orderByFields
+    }
+    return query
+  }
+
+  /**
+   * Converts geoservices orderByFields to a usable object
+   *
+   * @param {string} orderByFields - geoservices orderByFieldsString
+   * @return {array} order_by - An array of {field: order} objects
+   */
+  this._convertOrderByFields = function (orderByFields) {
+    var order_by = []
+    var orders = orderByFields.split(',')
+    orders.forEach(function (block) {
+      var fieldOrder = block.trim().split(' ')
+      var order = {}
+      order[fieldOrder[0]] = fieldOrder[1] || 'ASC'
+      order_by.push(order)
+    })
+    return order_by
   }
 
   /**

--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -1,3 +1,5 @@
+var _ = require('lodash')
+
 /**
  * Cache constructor.
  * Exposes methods for managing the underlying database.
@@ -129,7 +131,7 @@ function Cache () {
     var query = this.decodeGeoservices(options)
     this.db.select(table, query, function (err, result) {
       if (err) return callback(err)
-      self.process(type, key, result, options, callback)
+      self.process(type, key, result, query, callback)
     })
   }
 
@@ -139,7 +141,8 @@ function Cache () {
    * @param {object} query - an object with geoservices strings
    * @return {object} parsed sql parts
    */
-  this.decodeGeoservices = function (query) {
+  this.decodeGeoservices = function (options) {
+    var query = _.clone(options)
     if (query.orderByFields && query.orderByFields.length) {
       query.order_by = this._convertOrderByFields(query.orderByFields)
       delete query.orderByFields

--- a/test/models/cache-test.js
+++ b/test/models/cache-test.js
@@ -40,4 +40,18 @@ describe('Cache Model Tests', function () {
       })
     })
   })
+
+  describe('converting geoservices to sql parts', function () {
+    it('should correctly parse orderByFields', function (done) {
+      var query = {orderByFields: 'water DESC, trees ASC'}
+      var test = Cache.decodeGeoservices(query)
+      test.order_by.length.should.equal(2)
+      Object.keys(test.order_by[0])[0].should.equal('water')
+      Object.keys(test.order_by[1])[0].should.equal('trees')
+      test.order_by[0].water.should.equal('DESC')
+      console.log(test.order_by)
+      test.order_by[1].trees.should.equal('ASC')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This PR sends sort options down to the db where it belongs. Previously if you used a sort and a limit simeltaneously you risked getting the wrong features if there are more features than the limit. This occured because sorting was only happening after features were retreived.

There is also the start here to functions that belong in a "geoservices interface" since we don't yet know what the structure/API for an interface is, I think this is the best place for these two functions for now.

What do you think @ngoldman?