### PR TITLE
BaseController refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.7.1] - 2015-09-10 
+## Unreleased
+### Changed
+* refactored `lib/BaseController`
+  * `BaseController.processFeatureServer` no longer requires `callback` parameter for jsonp
+
+## [2.7.1] - 2015-09-10
 ### Changed
 * refactored `lib/FeatureServices` & `lib/Query` (no more `this`)
 * added jsdoc to some lib files (BaseModel, FeatureServices, Query, GeoJSON, Logger)

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -1,4 +1,15 @@
 var featureServices = require('./FeatureServices')
+var arcServerInfo = {
+  currentVersion: 10.21,
+  fullVersion: '10.2.1',
+  soapUrl: 'http://sampleserver6.arcgisonline.com/arcgis/services',
+  secureSoapUrl: 'https://sampleserver6.arcgisonline.com/arcgis/services',
+  authInfo: {
+    isTokenBasedSecurity: true,
+    tokenServicesUrl: 'https://sampleserver6.arcgisonline.com/arcgis/tokens/',
+    shortLivedTokenValidity: 60
+  }
+}
 
 /**
  * A base controller that we can use as a prototype
@@ -22,21 +33,7 @@ function Controller () {
     if (!data) return res.status(400).send('There a problem accessing this repo')
 
     // check for info requests and respond like ArcGIS Server would
-    if (req._parsedUrl.pathname.substr(-4) === 'info') {
-      var arcGisServerLikeResponse = {
-        currentVersion: 10.21,
-        fullVersion: '10.2.1',
-        soapUrl: 'http://sampleserver6.arcgisonline.com/arcgis/services',
-        secureSoapUrl: 'https://sampleserver6.arcgisonline.com/arcgis/services',
-        authInfo: {
-          isTokenBasedSecurity: true,
-          tokenServicesUrl: 'https://sampleserver6.arcgisonline.com/arcgis/tokens/',
-          shortLivedTokenValidity: 60
-        }
-      }
-
-      return res.status(200).send(arcGisServerLikeResponse)
-    }
+    if (req._parsedUrl.pathname.substr(-4) === 'info') return res.send(arcServerInfo)
 
     if (featureServices[req.params.layer]) {
       // requests for specific layers - pass data and the query string

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -27,8 +27,6 @@ function Controller () {
    * @param  {Function} callback
    */
   function processFeatureServer (req, res, err, data, callback) {
-    delete req.query.geometry
-
     if (err) return res.status(500).json(err)
     if (!data) return res.status(400).send('There a problem accessing this repo')
 

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -26,6 +26,10 @@ function Controller () {
    * @param {object} data - some data to process
    */
   function processFeatureServer (req, res, err, data) {
+    // TODO: don't delete properties of `req`
+    // affects cache & query filtering in lib/Query
+    delete req.query.geometry
+
     if (err) return res.status(500).jsonp(err)
     if (!data) return res.status(400).jsonp(new Error('No data found'))
 

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -34,16 +34,7 @@ function Controller () {
 
     if (featureServices[req.params.layer]) {
       // requests for specific layers - pass data and the query string
-      featureServices[req.params.layer](data, req.query || {}, function (err, d) {
-        if (err) return res.status(400).jsonp(err)
-
-        // limit response to 1000
-        if (d.feature && d.features.length > 1000) {
-          d.features = d.features.splice(0, 1000)
-        }
-
-        res.jsonp(d)
-      })
+      featureServices[req.params.layer](data, req.query || {}, _handleFeatureData)
     } else {
       // have a layer
       if (req.params.layer && data[req.params.layer]) {
@@ -55,16 +46,7 @@ function Controller () {
 
       if (req.params.method && featureServices[req.params.method]) {
         // we have a method call like "/layers"
-        featureServices[req.params.method](data, req.query || {}, function (err, d) {
-          // limit response to 1000
-          if (err) return res.status(400).jsonp(err)
-
-          if (d.features && d.features.length > 1000) {
-            d.features = d.features.splice(0, 1000)
-          }
-
-          res.jsonp(d)
-        })
+        featureServices[req.params.method](data, req.query || {}, _handleFeatureData)
       } else {
         // make a straight up feature service info request
         // we still pass the layer here to conform to info method, though its undefined
@@ -73,6 +55,22 @@ function Controller () {
           res.jsonp(d)
         })
       }
+    }
+
+    /**
+     * private function for handling data from featureServices methods
+     *
+     * @param {Error} err - error
+     * @param {object} featureData - feature service data returned from featureServices method
+     */
+    function _handleFeatureData (err, featureData) {
+      if (err) return res.status(400).jsonp(err)
+
+      // limit response to 1000
+      var over1000 = featureData.features && featureData.features.length > 1000
+      if (over1000) featureData.features = featureData.features.splice(0, 1000)
+
+      res.jsonp(featureData)
     }
   }
 

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -17,8 +17,8 @@ var arcServerInfo = {
  */
 function Controller () {
   /**
-   * shared logic for handling Feature Service requests
-   * most providers will use this mehtod to figure out what request is being made
+   * Shared logic for handling Feature Service requests.
+   * Most providers will use this method to figure out what request is being made.
    *
    * @param {object} req - incoming server request
    * @param {object} res - outgoing server response
@@ -30,32 +30,31 @@ function Controller () {
     if (!data) return res.status(400).jsonp(new Error('No data found'))
 
     // check for info requests and respond like ArcGIS Server would
-    if (req._parsedUrl.pathname.substr(-4) === 'info') return res.jsonp(arcServerInfo)
+    var isInfoRequest = req._parsedUrl.pathname.substr(-4) === 'info'
+    if (isInfoRequest) return res.jsonp(arcServerInfo)
 
-    if (featureServices[req.params.layer]) {
-      // requests for specific layers - pass data and the query string
-      featureServices[req.params.layer](data, req.query || {}, _handleFeatureData)
-    } else {
-      // have a layer
-      if (req.params.layer && data[req.params.layer]) {
-        // pull out the layer data
-        data = data[req.params.layer]
-      } else if (req.params.layer && !data[req.params.layer]) {
-        return res.status(404).jsonp(new Error('Layer not found'))
-      }
+    var layer = req.params.layer
+    var method = req.params.method
+    var query = req.query || {}
 
-      if (req.params.method && featureServices[req.params.method]) {
-        // we have a method call like "/layers"
-        featureServices[req.params.method](data, req.query || {}, _handleFeatureData)
-      } else {
-        // make a straight up feature service info request
-        // we still pass the layer here to conform to info method, though its undefined
-        featureServices.info(data, req.params.layer, req.query, function (err, d) {
-          if (err) return res.status(500).jsonp(err)
-          res.jsonp(d)
-        })
-      }
+    // requests for specific layers - pass data and the query string
+    if (featureServices[layer]) return featureServices[layer](data, query, _handleFeatureData)
+
+    if (layer) {
+      // pull out the layer data or return 404
+      if (data[layer]) data = data[layer]
+      else return res.status(404).jsonp(new Error('Layer not found'))
     }
+
+    // we have a method call like "/layers"
+    if (method && featureServices[method]) return featureServices[method](data, query, _handleFeatureData)
+
+    // make a straight up feature service info request
+    // we still pass the layer here to conform to info method, though it's undefined
+    featureServices.info(data, layer, query, function (err, featureData) {
+      if (err) return res.status(500).jsonp(err)
+      res.jsonp(featureData)
+    })
 
     /**
      * private function for handling data from featureServices methods

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -20,35 +20,29 @@ function Controller () {
    * shared logic for handling Feature Service requests
    * most providers will use this mehtod to figure out what request is being made
    *
-   * @param  {Object}   req
-   * @param  {Object}   res
-   * @param  {Object}   err
-   * @param  {Object}   data
-   * @param  {Function} callback
+   * @param {object} req - incoming server request
+   * @param {object} res - outgoing server response
+   * @param {object} err - an error for some reason (this really shouldn't be here)
+   * @param {object} data - some data to process
    */
-  function processFeatureServer (req, res, err, data, callback) {
-    if (err) return res.status(500).json(err)
-    if (!data) return res.status(400).send('There a problem accessing this repo')
+  function processFeatureServer (req, res, err, data) {
+    if (err) return res.status(500).jsonp(err)
+    if (!data) return res.status(400).jsonp(new Error('No data found'))
 
     // check for info requests and respond like ArcGIS Server would
-    if (req._parsedUrl.pathname.substr(-4) === 'info') return res.send(arcServerInfo)
+    if (req._parsedUrl.pathname.substr(-4) === 'info') return res.jsonp(arcServerInfo)
 
     if (featureServices[req.params.layer]) {
       // requests for specific layers - pass data and the query string
       featureServices[req.params.layer](data, req.query || {}, function (err, d) {
-        if (err) {
-          res.status(400).send(err)
-          return
-        }
+        if (err) return res.status(400).jsonp(err)
+
         // limit response to 1000
         if (d.feature && d.features.length > 1000) {
           d.features = d.features.splice(0, 1000)
         }
-        if (callback) {
-          res.send(callback + '(' + JSON.stringify(d) + ')')
-        } else {
-          res.json(d)
-        }
+
+        res.jsonp(d)
       })
     } else {
       // have a layer
@@ -56,38 +50,27 @@ function Controller () {
         // pull out the layer data
         data = data[req.params.layer]
       } else if (req.params.layer && !data[req.params.layer]) {
-        res.status(404).send('Layer not found')
+        return res.status(404).jsonp(new Error('Layer not found'))
       }
+
       if (req.params.method && featureServices[req.params.method]) {
         // we have a method call like "/layers"
         featureServices[req.params.method](data, req.query || {}, function (err, d) {
           // limit response to 1000
-          if (err) {
-            res.status(400).send(err)
-            return
-          }
+          if (err) return res.status(400).jsonp(err)
+
           if (d.features && d.features.length > 1000) {
             d.features = d.features.splice(0, 1000)
           }
-          if (callback) {
-            res.send(callback + '(' + JSON.stringify(d) + ')')
-          } else {
-            res.json(d)
-          }
+
+          res.jsonp(d)
         })
       } else {
         // make a straight up feature service info request
         // we still pass the layer here to conform to info method, though its undefined
         featureServices.info(data, req.params.layer, req.query, function (err, d) {
-          if (err) {
-            if (callback) callback(err)
-            else res.status(500).send(err)
-          }
-          if (callback) {
-            res.send(callback + '(' + JSON.stringify(d) + ')')
-          } else {
-            res.json(d)
-          }
+          if (err) return res.status(500).jsonp(err)
+          res.jsonp(d)
         })
       }
     }


### PR DESCRIPTION
This PR simplifies the processFeatureServer method without any breaking changes.

* callback param removed in favor of using [`res.jsonp`](http://expressjs.com/api.html#res.jsonp) (same result)
* removed line deleting req.query.geometry for no reason
* DRY for featureServices method callbacks
* return early wherever possible
* return more informative errors
* reduce nesting and use of unnecessary `if/else` blocks

This should be 100% functionally equivalent to the previous version. A close reading from @dmfenton is probably a good idea.

Something to note:

`res.jsonp` returns a response wrapped in a jsonp callback using `req.params.callback` if it's defined. If `req.params.callback` is not defined it behaves the same as `res.json` (see [res.jsonp method](https://github.com/strongloop/express/blob/f73ff9243006ea010fffdaa748f06df3a5b986e7/lib/response.js#L264-L318) for reference). This is something we could use in a lot of [other places](https://github.com/search?q=req.query.callback+user%3Akoopjs&type=Code&utf8=%E2%9C%93).