### PR TITLE
fixes and better tests for exporting geometry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '0.12'
+  - 'stable'
   - '0.10'
 sudo: false # Enable docker-based containers
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Travis tests against stable Node
+
+### Fixed
+* Set geometry type on export when there is no srid
+* Never overwrrite existing X or Y fields in CSV
+* CSV written with geometry fields even if first geometry is null
+
 ## [2.8.1] - 2015-09-18 
 ### Fixed
 * Better test and support for null geometry in exports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Set geometry type on export when there is no srid
 * Never overwrrite existing X or Y fields in CSV
-* CSV written with geometry fields even if first geometry is null
+* CSV is now written with geometry fields even if first geometry is null
+* No longer throwing an execption on datasets with no geometry at all
 
 ## [2.8.1] - 2015-09-18 
 ### Fixed

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -474,7 +474,12 @@ function getOgrParams (format, inFile, outFile, geojson, options, callback) {
   var feature = _.find(geojson.features, function (feature) {
     return feature.geometry !== null
   })
-  options.geometryType = feature.geometry.type
+
+  if (feature && feature.geometry) {
+    options.geometryType = feature.geometry.type
+  } else {
+    options.geometryType = 'NONE'
+  }
 
   if (format === 'csv') {
     options.fields = Object.keys(geojson.features[0].properties)

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -495,8 +495,6 @@ function csvParams (cmd, options) {
   var hasPointGeom = options.geometryType === 'Point'
   var fields = options.fields.join('|').toLowerCase().split('|')
   var hasXY = _.include(fields, 'x') || _.include(fields, 'y')
-  console.log(hasXY)
-  console.log(hasPointGeom)
   if (hasPointGeom && !hasXY) {
     cmd.push('-lco WRITE_BOM=YES')
     cmd.push('-lco GEOMETRY=AS_XY')

--- a/lib/Exporter.js
+++ b/lib/Exporter.js
@@ -471,15 +471,17 @@ function getOgrParams (format, inFile, outFile, geojson, options, callback) {
 
   var cmd = ['ogr2ogr', '--config', 'SHAPE_ENCODING', 'UTF-8', '-f', ogrFormats[format], outFile, inFile]
 
+  var feature = _.find(geojson.features, function (feature) {
+    return feature.geometry !== null
+  })
+  options.geometryType = feature.geometry.type
+
   if (format === 'csv') {
-    cmd = csvParams(geojson, cmd)
+    options.fields = Object.keys(geojson.features[0].properties)
+    cmd = csvParams(cmd, options)
     callback(null, finishOgrParams(cmd))
   } else if (format === 'zip' || format === 'shp') {
     // only project features for shp when wkid != 4326 or 3857 or 102100
-    var feature = _.find(geojson.features, function (feature) {
-      return feature.geometry !== null
-    })
-    options.geometryType = feature.geometry.type
     shapefileParams(cmd, options, function (err, cmd) {
       if (err) callback(err)
       callback(null, finishOgrParams(cmd))
@@ -489,21 +491,22 @@ function getOgrParams (format, inFile, outFile, geojson, options, callback) {
   }
 }
 
-function csvParams (geojson, cmd) {
-  // how would we even get here without geojson?? leaving this in only to prevent regressions
-  if (!geojson) return cmd
-  var hasPointGeom = geojson.features && geojson.features.length & geojson.features[0].geometry && geojson.features[0].geometry.type === 'Point'
-  var hasXY = (geojson.features[0].properties['x'] && geojson.features[0].properties['y']) || (geojson.features[0].properties['X'] && geojson.features[0].properties['Y'])
+function csvParams (cmd, options) {
+  var hasPointGeom = options.geometryType === 'Point'
+  var fields = options.fields.join('|').toLowerCase().split('|')
+  var hasXY = _.include(fields, 'x') || _.include(fields, 'y')
+  console.log(hasXY)
+  console.log(hasPointGeom)
   if (hasPointGeom && !hasXY) {
-    cmd.push('-lco')
-    cmd.push('WRITE_BOM=YES')
-    cmd.push('-lco')
-    cmd.push('GEOMETRY=AS_XY')
+    cmd.push('-lco WRITE_BOM=YES')
+    cmd.push('-lco GEOMETRY=AS_XY')
   }
   return cmd
 }
 
 function shapefileParams (cmd, options, callback) {
+  // make sure geometries are still written even if the first is null
+  cmd.push('-nlt ' + options.geometryType.toUpperCase())
   if (options.outSR) options.sr = formatSpatialRef(options.outSR)
   if (options.sr || options.wkid) {
     addProjection(options, function (err, wkt) {
@@ -511,13 +514,10 @@ function shapefileParams (cmd, options, callback) {
       cmd.push('-t_srs' + ' "' + wkt + '"')
       // make sure field names are not truncated multiple times
       cmd.push('-fieldmap identity')
-      // make sure geometries are still written even if the first is null
-      cmd.push('-nlt ' + options.geometryType.toUpperCase())
       callback(null, cmd)
     })
   } else {
-    cmd.push('-fieldmap')
-    cmd.push('identity')
+    cmd.push('-fieldmap identity')
     callback(null, cmd)
   }
 }

--- a/test/models/exporter-test.js
+++ b/test/models/exporter-test.js
@@ -4,6 +4,7 @@ var should = require('should')
 var exporter = require('../../lib/Exporter')
 var snowData = require('../fixtures/snow.geojson')
 var nock = require('nock')
+var _ = require('lodash')
 
 function noop () {}
 
@@ -82,7 +83,9 @@ describe('exporter Model', function () {
           type: 'Feature',
           geometry: null,
           properties: {
-            name: 'Foo'
+            name: 'Foo',
+            X: false,
+            Y: false
           }
         },
         {
@@ -92,13 +95,15 @@ describe('exporter Model', function () {
             coordinates: [125.6, 10.1]
           },
           properties: {
-            name: 'Dinagat Islands'
+            name: 'Dinagat Islands',
+            X: false,
+            Y: false
           }
         }
       ]
     }
 
-    it('should create a correct ogr string of commands', function (done) {
+    it('should create a correct ogr string of commands for a csv when there are x y features', function (done) {
       var format = 'csv'
       var inFile = 'infile.json'
       var outFile = 'outfile.csv'
@@ -109,9 +114,43 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        var params = cmd.split(' ')
-        params[6].should.equal(outFile)
-        params[7].should.equal(inFile)
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f CSV outfile.csv infile.json -update -append -skipfailures -lco ENCODING=UTF-8')
+        done()
+      })
+    })
+
+    it('should create a correct ogr string of commands for a csv when there are not x or y features', function (done) {
+      var format = 'csv'
+      var inFile = 'infile.json'
+      var outFile = 'outfile.csv'
+
+      var options = {
+        name: 'dummy'
+      }
+
+      var json = _.clone(geojson)
+      delete json.features[0].properties.X
+      delete json.features[0].properties.Y
+
+      exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
+        should.not.exist(err)
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f CSV outfile.csv infile.json -lco WRITE_BOM=YES -lco GEOMETRY=AS_XY -update -append -skipfailures -lco ENCODING=UTF-8')
+        done()
+      })
+    })
+
+    it('should create a correct ogr string of commands for a shapefile without srid', function (done) {
+      var format = 'zip'
+      var inFile = 'infile.json'
+      var outFile = 'outfile.shp'
+
+      var options = {
+        name: 'dummy'
+      }
+
+      exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
+        should.not.exist(err)
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })
@@ -128,7 +167,7 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -t_srs "PROJCS["NGO_1948_Norway_Zone_1",GEOGCS["GCS_NGO_1948",DATUM["D_NGO_1948",SPHEROID["Bessel_Modified",6377492.018,299.1528128]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",6.05625],PARAMETER["Scale_Factor",1.0],PARAMETER["Latitude_Of_Origin",58.0],UNIT["Meter",1.0]]" -fieldmap identity -nlt POINT -update -append -skipfailures -lco ENCODING=UTF-8')
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -t_srs "PROJCS["NGO_1948_Norway_Zone_1",GEOGCS["GCS_NGO_1948",DATUM["D_NGO_1948",SPHEROID["Bessel_Modified",6377492.018,299.1528128]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",6.05625],PARAMETER["Scale_Factor",1.0],PARAMETER["Latitude_Of_Origin",58.0],UNIT["Meter",1.0]]" -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })
@@ -148,7 +187,7 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -t_srs "PROJCS["NAD83(CSRS) / UTM zone 21N",GEOGCS["NAD83(CSRS)",DATUM["NAD83_Canadian_Spatial_Reference_System",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[-0.9956,1.9013,0.5215,0.025915,0.009426,0.011599,-0.00062],AUTHORITY["EPSG","6140"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4617"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-57],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],AUTHORITY["EPSG","2962"],AXIS["Easting",EAST],AXIS["Northing",NORTH]]" -fieldmap identity -nlt POINT -update -append -skipfailures -lco ENCODING=UTF-8')
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -t_srs "PROJCS["NAD83(CSRS) / UTM zone 21N",GEOGCS["NAD83(CSRS)",DATUM["NAD83_Canadian_Spatial_Reference_System",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[-0.9956,1.9013,0.5215,0.025915,0.009426,0.011599,-0.00062],AUTHORITY["EPSG","6140"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4617"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-57],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],AUTHORITY["EPSG","2962"],AXIS["Easting",EAST],AXIS["Northing",NORTH]]" -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })
@@ -168,7 +207,7 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -t_srs "PROJCS["NAD83 / California zone 6 (ftUS)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",33.88333333333333],PARAMETER["standard_parallel_2",32.78333333333333],PARAMETER["latitude_of_origin",32.16666666666666],PARAMETER["central_meridian",-116.25],PARAMETER["false_easting",6561666.667],PARAMETER["false_northing",1640416.667],AUTHORITY["EPSG","2230"],AXIS["X",EAST],AXIS["Y",NORTH]]" -fieldmap identity -nlt POINT -update -append -skipfailures -lco ENCODING=UTF-8')
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -t_srs "PROJCS["NAD83 / California zone 6 (ftUS)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",33.88333333333333],PARAMETER["standard_parallel_2",32.78333333333333],PARAMETER["latitude_of_origin",32.16666666666666],PARAMETER["central_meridian",-116.25],PARAMETER["false_easting",6561666.667],PARAMETER["false_northing",1640416.667],AUTHORITY["EPSG","2230"],AXIS["X",EAST],AXIS["Y",NORTH]]" -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })
@@ -188,7 +227,7 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -t_srs "PROJCS["NAD83(HARN) / Washington South (ftUS)",GEOGCS["NAD83(HARN)",DATUM["NAD83_High_Accuracy_Regional_Network",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[-0.9956,1.9013,0.5215,0.025915,0.009426,0.011599,-0.00062],AUTHORITY["EPSG","6152"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4152"]],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",47.33333333333334],PARAMETER["standard_parallel_2",45.83333333333334],PARAMETER["latitude_of_origin",45.33333333333334],PARAMETER["central_meridian",-120.5],PARAMETER["false_easting",1640416.667],PARAMETER["false_northing",0],AUTHORITY["EPSG","2927"],AXIS["X",EAST],AXIS["Y",NORTH]]" -fieldmap identity -nlt POINT -update -append -skipfailures -lco ENCODING=UTF-8')
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -t_srs "PROJCS["NAD83(HARN) / Washington South (ftUS)",GEOGCS["NAD83(HARN)",DATUM["NAD83_High_Accuracy_Regional_Network",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[-0.9956,1.9013,0.5215,0.025915,0.009426,0.011599,-0.00062],AUTHORITY["EPSG","6152"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4152"]],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",47.33333333333334],PARAMETER["standard_parallel_2",45.83333333333334],PARAMETER["latitude_of_origin",45.33333333333334],PARAMETER["central_meridian",-120.5],PARAMETER["false_easting",1640416.667],PARAMETER["false_northing",0],AUTHORITY["EPSG","2927"],AXIS["X",EAST],AXIS["Y",NORTH]]" -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })
@@ -208,7 +247,7 @@ describe('exporter Model', function () {
 
       exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
         should.not.exist(err)
-        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -t_srs "+title=Amersfoort/Amersfoort +proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.999908 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812" -fieldmap identity -nlt POINT -update -append -skipfailures -lco ENCODING=UTF-8')
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f "ESRI Shapefile" outfile.shp infile.json -nlt POINT -t_srs "+title=Amersfoort/Amersfoort +proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.999908 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812" -fieldmap identity -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })

--- a/test/models/exporter-test.js
+++ b/test/models/exporter-test.js
@@ -128,13 +128,32 @@ describe('exporter Model', function () {
         name: 'dummy'
       }
 
-      var json = _.clone(geojson)
+      var json = _.cloneDeep(geojson)
       delete json.features[0].properties.X
       delete json.features[0].properties.Y
 
-      exporter.getOgrParams(format, inFile, outFile, geojson, options, function (err, cmd) {
+      exporter.getOgrParams(format, inFile, outFile, json, options, function (err, cmd) {
         should.not.exist(err)
         cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f CSV outfile.csv infile.json -lco WRITE_BOM=YES -lco GEOMETRY=AS_XY -update -append -skipfailures -lco ENCODING=UTF-8')
+        done()
+      })
+    })
+
+    it('should create a valid ogr string for csv when there is no geometry', function (done) {
+      var format = 'csv'
+      var inFile = 'infile.json'
+      var outFile = 'outfile.csv'
+
+      var options = {
+        name: 'dummy'
+      }
+      var json = _.cloneDeep(geojson)
+      json.features[0].geometry = null
+      json.features[1].geometry = null
+
+      exporter.getOgrParams(format, inFile, outFile, json, options, function (err, cmd) {
+        should.not.exist(err)
+        cmd.should.equal('ogr2ogr --config SHAPE_ENCODING UTF-8 -f CSV outfile.csv infile.json -update -append -skipfailures -lco ENCODING=UTF-8')
         done()
       })
     })


### PR DESCRIPTION
This PR fixes a couple related bugs around exporting geometry with OGR2OGR. Previously we only checked the first feature for geometry, now we check for the first non-null geometry.

@koopjs/dev 