### PR TITLE
dont set display field that doesnt exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Gracefully handle malformed esri geoms in geojson conversion
 * Revert Windows command line escaping, it was done improperly
 * Always tranform datum for NAD83 exports
+* No longer setting a display field that doesnt exist (or any display field at all)
 
 ## [2.8.4] - 2015-09-24
 ### Fixed

--- a/lib/templates/featureLayer.json
+++ b/lib/templates/featureLayer.json
@@ -3,7 +3,7 @@
 	"id" : 0,
 	"name" : "Not Set",
 	"type" : "Feature Layer",
-	"displayField" : "id",
+	"displayField" : "",
 	"description" : "",
 	"copyrightText" : "",
 	"defaultVisibility": true,


### PR DESCRIPTION
This resolves a small bug in ArcGIS Open Data where the map display field value shows up as undefined because the "id" field does not exist. Now Open Data can just choose the first non-objectID field.