### PR TITLE
Refactor of Export Workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Resources are no longer set to `processing` when export jobs are running.
+* Resources have progress reported on specific option keys
+* Export generation locks are set only on specific option keys instead of the entire resource
+* New class handles export job creation
+* Broke ExportWorker into multiple subjobs
+* Queue creation logic is moved out of the index
+* The ExportWorker only updates the DB if the job failed
+* All ExportWorker errors are saved to the resource info doc.
+
+### Fixed
+* Typo no longer prevents s3 filesystem from initializing
+
 ## [2.8.6] - 2015-10-01
 ### Fixed
 * LocalDB `select` method now works properly if `options.layer` is omitted or included in key string

--- a/lib/ExportJob.js
+++ b/lib/ExportJob.js
@@ -1,0 +1,107 @@
+/**
+ * Export Job constructor, creates and manages export jobs through their lifecycle
+ *
+ * @class
+ * @param {object} cache - the place where info about this job is stored
+ * @param {object} log - a logger to use
+ * @param {object} options - set of options describing how to create an export job
+ * @param {function} callback - calls back with an error or a status
+ */
+function ExportJob (helpers, options, done) {
+  this.cache = helpers.cache
+  this.queue = helpers.queue
+  this.log = helpers.log
+  this.options = options
+  this.done = done
+  this.completed = 0
+}
+
+/**
+ * Starts a new export job if appropriate
+ */
+ExportJob.prototype.start = function () {
+  var self = this
+  self._checkLock(function (locked) {
+    // if the job is locked, then we just want to return status
+    if (locked) return self.done(null, self.status, false)
+    self._createLock(function (err) {
+      if (err) return self.done(err)
+      self.done(null, self.status, true)
+      self.job = self.queue.create('exports', self.options).removeOnComplete(true).save(function (err) {
+        if (err) {
+          self.log.error('Unable to add job to export queue: ' + err + ' ' + JSON.stringify(self.options))
+          return self.done(err)
+        }
+        self.log.debug('Added job to export queue ' + self.job.id)
+      })
+      self.job.on('progress', self._updateProgress.bind(self)) // TODO is this binding necessary?
+    })
+  })
+}
+
+/**
+ * Checks to see if a export job type should proceed
+ *
+ * @param {function} callback - calls back with a decision on whether to proceed and info
+ * @private
+ */
+ExportJob.prototype._checkLock = function (callback) {
+  var self = this
+  var key = self.options.key
+  var format = self.options.format
+  self.cache.getInfo(self.options.table, function (err, info) {
+    // save status to the ExportJob object because we're going to keep updating it
+    self.status = info
+    if (err) return self.done(err)
+    // this key doesn't exist at all in the generating object -> new job
+    if (!info.generating || !info.generating[key]) return callback(false)
+    // koop is in the process of requesting rows from the DB -> no new job
+    if (info.generating[key].progress && info.generating[key].progress !== '100%') return callback(true)
+    // koop is currently creating this format for this resource and key -> no new job
+    if (info.generating[key][format]) return callback(true)
+    // koop has already gotten the rows from the db but hasn't seen this format before -> new job
+    callback(false)
+  })
+}
+
+/**
+ * Creates a lock on the data and/or export format
+ *
+ * @param {function} callback - calls back with an error or nothing
+ */
+ExportJob.prototype._createLock = function (callback) {
+  var status = this.status
+  var key = this.options.key
+  var format = this.options.format
+
+  status.generating = status.generating ? status.generating : {}
+  status.generating[key] = status.generating[key] || {progress: 0 + '%'}
+  status.generating[key].start = Date.now()
+  status.generating[key][format] = true
+  this.cache.updateInfo(this.options.table, status, callback)
+}
+
+/**
+ * Updates the progress of a particular export job in the db
+ * We request info before updating it is that we cannot
+ * update postgres json in place and another worker may be processing
+ * a different data key
+ *
+ * @param {float} progress - measure of database rows written to disk
+ * @private
+ */
+ExportJob.prototype._updateProgress = function (pages, length) {
+  var self = this
+  self.completed++
+  var progress = (self.completed / length) * 100
+  self.cache.getInfo(self.options.table, function (err, info) {
+    if (err) return self.done(err)
+    info.generating[self.options.key].progress = progress + '%'
+    self.cache.updateInfo(self.options.table, info, function (err) {
+      if (err) return self.done(err)
+      self.log.debug('job progress: ' + self.job.id + ' ' + progress + '%')
+    })
+  })
+}
+
+module.exports = ExportJob

--- a/lib/ExportQueue.js
+++ b/lib/ExportQueue.js
@@ -1,0 +1,31 @@
+var kue = require('kue')
+
+module.exports = {
+  /**
+   * Creates a new export queue
+   *
+   * @param {object} options - contains configuration for the queue and a logger
+   */
+  create: function (options) {
+    var log = options.log
+    var export_q = kue.createQueue({
+      prefix: options.redis.prefix,
+      disableSearch: true,
+      redis: {
+        port: options.redis.port,
+        host: options.redis.host
+      }
+    })
+
+    export_q.on('failed', function (id, jobErr) {
+      kue.Job.get(id, function (err, job) {
+        if (err) return log.error(JSON.stringify(err), job)
+        job.remove(function (err) {
+          if (err) return log.debug('Export Workers: failed to remove failed job #' + job.id + ' Error: ' + jobErr)
+          log.debug('Export Workers: removed failed job #' + job.id + ' Error: ' + jobErr)
+        })
+      })
+    })
+    return export_q
+  }
+}

--- a/lib/ExportWorker.js
+++ b/lib/ExportWorker.js
@@ -1,7 +1,7 @@
 var kue = require('kue')
 var fs = require('node-fs')
 var async = require('async')
-var koopLib = require('./')
+var koop = require('./')
 var pgcache = require('koop-pgcache')
 var path = require('path')
 var rimraf = require('rimraf')
@@ -20,13 +20,18 @@ if (!config.export_workers) {
 }
 
 // set up koop with the thing we need like logging and the cache
-koopLib.config = config
-koopLib.log = new koopLib.Logger(config)
-koopLib.Cache = new koopLib.DataCache(koopLib)
-koopLib.files = new koopLib.Files(koopLib)
+koop.config = config
+koop.log = new koop.Logger(config)
+var cache = new koop.DataCache(koop)
+var files = new koop.Files(koop)
+if (files.s3) {
+  koop.log.info('S3 file system initialized in bucket: ' + files.s3Bucket)
+} else {
+  koop.log.warn('S3 file system is not configured')
+}
 
 // registers a DB modules
-koopLib.Cache.db = pgcache.connect(config.db.conn, koopLib)
+cache.db = pgcache.connect(config.db.conn, koop)
 
 // create the job queue
 var jobs = kue.createQueue({
@@ -41,318 +46,310 @@ var jobs = kue.createQueue({
 // in practice it leads to memory allocation errors when handling multiple large datasets
 var concurrency = config.export_workers.concurrency || 1
 jobs.process('exports', concurrency, function (job, done) {
-  console.log('starting export job', job.id)
+  koop.log.info('starting export job', job.id)
 
   var domain = require('domain').create()
-
+  // All runtime errors will be funnelled through this function.
+  // That's why we throw errors instead of calling the callback
   domain.on('error', function (err) {
+    handleError(job.data.table, job.data.key, err)
     done(err)
   })
 
   domain.run(function () {
     // Jobs for removing files from the local FS
-    if (job.data.remove) {
-      // remove
-      // simply blow away the local dir for the given data set
-      var dir = path.join(koopLib.files.localDir, 'files', (job.data.itemId + '_' + job.data.layerId))
-
-      rimraf(dir, function (err) {
-        if (err) done(err)
-        return done()
-      })
-
-    // if we have VRT file we can use that to create a new export
-    } else {
-      koopLib.Cache.getCount(job.data.table, job.data.options, function (err, count) {
-        if (err) done(err)
-
-        // if we can handle the data in one page
-        if (count <= job.data.options.limit) {
-          job.data.options.bypassProcessing = true
-          koopLib.Cache.db.select(job.data.dbkey, job.data.options, function (err, geojson) {
-            if (err) done(err)
-
-            delete geojson[0].info
-            koopLib.Exporter.exportToFormat(
-              job.data.options.format,
-              job.data.options.dir,
-              job.data.options.key,
-              geojson[0],
-              job.data.options,
-              function (err, result) {
-                if (err) return done(err)
-
-                finishExport(
-                  job.data.format,
-                  job.data.options.key,
-                  job.data.options,
-                  result,
-                  function (err, path) {
-                    if (err) done(err)
-
-                    koopLib.Cache.getInfo(job.data.table, function (err, info) {
-                      if (err) done(err)
-
-                      delete info.status
-                      delete info.generating
-                      delete info.export_lock
-
-                      koopLib.Cache.updateInfo(job.data.table, info, function (err, res) {
-                        if (err) return done(err)
-                        return done()
-                      })
-                    })
-                  }
-                )
-              })
-          })
-        } else if (fs.existsSync(job.data.files.rootVrtFile) && !job.data.options.ignore_cache) {
-          // else if we already have a VRT
-          // since we have a VRT file locally
-          // we just want to create the export and complete the job
-          koopLib.Cache.getInfo(job.data.table, function (err, info) {
-            if (err) {
-              console.log('vrt file exists, but no data in the db', job.data.files.rootVrtFile)
-              return done('failed to generate export' + err)
-            }
-
-            info.status = 'processing'
-            info.generating = {
-              progress: 100 + '%'
-            }
-
-            koopLib.Cache.updateInfo(job.data.table, info, function (err, res) {
-              if (err) return done(err)
-
-              try {
-                var params = {
-                  inFile: job.data.files.rootVrtFile,
-                  outFile: job.data.files.rootNewFile,
-                  paths: job.data.files,
-                  format: job.data.format
-                }
-
-                var options = job.data.options
-                options.large = true
-                options.db = koopLib.Cache.db
-                options.logger = koopLib.log
-                var fileLoc = path.join(path.dirname(params.inFile), 'part.0.json')
-                var geojson = JSON.parse(fs.readFileSync(fileLoc))
-                koopLib.Exporter.callOgr(params, geojson, job.data.options, function (err, formatFile) {
-                  if (err) return done(err)
-
-                  // remove the processing state and return the job
-                  delete info.status
-                  delete info.generating
-                  delete info.export_lock
-                  finishExport(
-                    job.data.format,
-                    job.data.options.key,
-                    job.data.options,
-                    { paths: job.data.files, file: formatFile },
-                    function () {
-                      koopLib.Cache.updateInfo(job.data.table, info, function (e, res) {
-                        if (err) return done(err)
-                        return done()
-                      })
-                    }
-                  )
-                })
-              } catch (e) {
-                console.log('error calling org', e)
-                info.generating = { error: e }
-                koopLib.Cache.updateInfo(job.data.table, info, function (err, res) {
-                  if (err) return done(err)
-                  done('failed to generate file ' + e)
-                })
-              }
-            })
-          })
-        } else {
-          fs.mkdir(job.data.files.base, '0777', true, function () {
-            koopLib.Cache.getCount(job.data.table, job.data.options, function (err, count) {
-              if (err) return done(err)
-
-              var pages = Math.ceil(count / job.data.options.limit)
-
-              for (var i = 0; i < pages; i++) {
-                var offset = (i * (job.data.options.limit)) + 1
-                var chunk = { file: job.data.files.base + '/part.' + i + '.json', offset: offset }
-                job.data.pages.push(chunk)
-              }
-
-              createFiles(job, done)
-            })
-          })
-        }
-      })
-    }
+    if (job.data.remove) return remove(job, done)
+    cache.getCount(job.data.table, job.data.options, function (err, count) {
+      if (err) throw err
+      // if we can handle the data in one page
+      if (count <= job.data.options.limit) {
+        singlePage(job, done)
+      // if we already have a VRT on disk
+      } else if (fs.existsSync(job.data.paths.rootVrtFile) && !job.data.options.ignore_cache) {
+        createFromVRT(job, done)
+      // we need to start from scratch
+      } else {
+        multiPage(job, count, done)
+      }
+    })
   })
 })
 
-function createFiles (job, done) {
-  var vrt = '<OGRVRTDataSource>'
-  var pageLen = job.data.pages.length
-  var completed = 0
+/**
+ * Handles errors thrown by any of the jobs or sub jobs
+ *
+ * @param {string} table - the db table name
+ * @param {string} key - hash representing filters applied to the data
+ * @param {object} error - the error thrown by the job
+ */
+function handleError (table, key, error) {
+  cache.getInfo(table, function (err, info) {
+    if (err) koop.log.error(err)
+    info.generating[key].error = JSON.stringify(error)
+    cache.updateInfo(table, info, function (err) {
+      if (err) koop.log.error(err)
+    })
+  })
+}
 
-  // create a new VRT File
-  fs.appendFileSync(job.data.files.rootVrtFile, vrt)
+/**
+ * Sub-job to remove files from the local dir
+ *
+ * @param {object} job - contains information about how to complete the job
+ * @param {function} done - a callback for when the job is completed
+ * @private
+ */
+function remove (job, done) {
+  // remove
+  // simply blow away the local dir for the given data set
+  var dir = path.join(files.localDir, 'files', (job.data.itemId + '_' + job.data.layerId))
 
-  var workerQ = async.queue(function (task, cb) {
-    // make sure offset is in options for creating the idFilter below
-    task.options.offset = task.offset
+  rimraf(dir, function (err) {
+    if (err) throw err
+    return done()
+  })
+}
 
-    var opts = {
-      layer: task.options.layer,
-      where: task.options.where,
-      idFilter: koopLib.Exporter.createIdFilter(task.options),
-      geometry: task.options.geometry,
-      bypassProcessing: true
-    }
+/**
+ * Sub-job to create from a single db page
+ *
+ * @param {object} job - contains information about how to complete the job
+ * @param {function} done - a callback for when the job is completed
+ * @private
+ */
+function singlePage (job, done) {
+  var format = job.data.format
+  var key = job.data.key
+  var options = job.data.options
 
-    var filePart = task.file
-
-    koopLib.Cache.db.select(task.dbkey, opts, function (err, json) {
-      if (err) return done(err)
-
-      koopLib.Cache.getInfo(task.table, function (err, info) {
-        if (err) return done(err)
-
-        if (json && json[0] && json[0].info) {
-          delete json[0].info
-          json = json[0]
-        }
-
-        var exists = fs.existsSync(filePart)
-
-        if (exists) {
-          fs.unlinkSync(filePart)
-        }
-
-        fs.writeFile(filePart, JSON.stringify(json), function () {
-          // tick up the number of complete pages
-          completed++
-          job.progress(completed, pageLen)
-
-          // TODO why build this here?
-          // we could open a file handle and push each layer into the file via io
-          var vrtPartial = '<OGRVRTLayer name="OGRGeoJSON"><SrcDataSource>'
-          vrtPartial += filePart
-          vrtPartial += '</SrcDataSource></OGRVRTLayer>'
-
-          fs.appendFileSync(task.files.rootVrtFile, vrtPartial)
-
-          if (completed === pageLen) {
-            // close the VRT
-            fs.appendFileSync(task.files.rootVrtFile, '</OGRVRTDataSource>')
-
-            var params = {
-              inFile: task.files.rootVrtFile,
-              outFile: task.files.rootNewFile,
-              paths: task.files,
-              format: task.format
-            }
-
-            try {
-              var fileLoc = path.join(path.dirname(params.inFile), 'part.0.json')
-              var geojson = JSON.parse(fs.readFileSync(fileLoc))
-              job.data.options.large = true
-              koopLib.Exporter.callOgr(params, geojson, job.data.options, function (err, formatFile) {
-                if (err) return done(err)
-
-                delete info.status
-                delete info.generating
-                delete info.export_lock
-
-                finishExport(
-                  task.format,
-                  task.options.key,
-                  task.options,
-                  { paths: task.files, file: formatFile },
-                  function () {
-                    koopLib.Cache.updateInfo(task.table, info, function (err, res) {
-                      if (err) return done(err)
-                      done()
-                      cb()
-                    })
-                  }
-                )
-              })
-            } catch (e) {
-              console.log('error calling org', e)
-              info.generating = { error: e }
-
-              koopLib.Cache.updateInfo(task.table, info, function (err, res) {
-                if (err) return done(err)
-                done('failed to generate file ' + e)
-                workerQ.kill()
-                cb()
-              })
-            }
-          } else {
-            cb()
-          }
-        })
+  cache.db.select(job.data.dbKey, options, function (err, geojson) {
+    if (err) throw err
+    koop.Exporter.exportToFormat(format, job.data.dir, key, geojson[0], options, function (err, result) {
+      if (err) throw err
+      finishExport(format, key, options, result, function (err, path) {
+        if (err) throw err
+        job.progress(1, 1)
+        done()
       })
     })
-  }, 4)
+  })
+}
+
+/**
+ * Sub-job to create an exported file from multiple pages
+ * First it will request pages of json and save them to disk while building a vrt layer
+ * then it will call OGR2OGR using the VRT layer as input
+ *
+ * @param {object} job - contains information about how to complete the job
+ * @param {integer} count - the number of pages
+ * @param {function} done - a callback for when the job is completed
+ * @private
+ */
+function multiPage (job, count, done) {
+  fs.mkdir(job.data.paths.base, '0777', true, function () {
+    var pages = Math.ceil(count / job.data.options.limit)
+
+    for (var i = 0; i < pages; i++) {
+      var offset = (i * (job.data.options.limit)) + 1
+      var chunk = { file: job.data.paths.base + '/part.' + i + '.json', offset: offset }
+      job.data.pages.push(chunk)
+    }
+
+    createFiles(job, done)
+  })
+}
+
+/**
+ * Sub-job to create an exported file from multiple pages
+ * First it will request pages of json and save them to disk while building a vrt layer
+ * then it will call OGR2OGR using the VRT layer as input
+ *
+ * @param {object} job - contains information about how to complete the job
+ * @param {function} done - a callback for when the job is completed
+ * @private
+ */
+function createFromVRT (job, done) {
+  // else if we already have a VRT
+  // since we have a VRT file locally
+  // we just want to create the export and complete the job
+  var params = {
+    inFile: job.data.paths.rootVrtFile,
+    outFile: job.data.paths.rootNewFile,
+    paths: job.data.paths,
+    format: job.data.format
+  }
+
+  var options = job.data.options
+  options.large = true
+  options.db = cache.db
+  options.logger = koop.log
+  var fileLoc = path.join(path.dirname(params.inFile), 'part.0.json')
+  var geojson = JSON.parse(fs.readFileSync(fileLoc))
+
+  try {
+    koop.Exporter.callOgr(params, geojson, job.data.options, function (err, formatFile) {
+      if (err) throw err
+      var paths = { paths: job.data.paths, file: formatFile }
+      finishExport(job.data.format, job.data.key, job.data.options, paths, done)
+    })
+  } catch (e) {
+    koop.log.error('error calling OGR2OGR', e)
+    throw e
+  }
+}
+
+/**
+ * Sub-job to page over the DB writing JSON to disk and building a VRT layer
+ *
+ * @param {object} job - contains information about how to complete the job
+ * @param {function} done - a callback for when the job is completed
+ * @private
+ */
+function createFiles (job, done) {
+  var vrt = '<OGRVRTDataSource>'
+
+  // create a new VRT File
+  fs.appendFileSync(job.data.paths.rootVrtFile, vrt)
 
   job.data.pages.forEach(function (page, i) {
     var task = {
       options: job.data.options,
       file: page.file,
       offset: page.offset,
-      dbkey: job.data.dbkey,
+      dbKey: job.data.dbKey,
       table: job.data.table,
       format: job.data.format,
       ogrFormat: job.data.ogrFormat,
-      files: job.data.files
+      files: job.data.paths,
+      done: done,
+      job: job
     }
 
-    workerQ.push(task, function (err) { if (err) console.log(err) })
+    workerQ.push(task, function (err) {
+      if (err) koop.log.error(err)
+    })
   })
 }
 
-// This method is duplicate method from whats in the BaseModel.
-// since workers are removed from koop providers we dont have access to
-// these methods in the workers.
-// This function finishes the export by cleaning up after it self and uploading to s3
+var workerQ = async.queue(function (task, cb) {
+  var job = task.job
+  var pageLen = job.data.pages.length
+  var self = this
+  workerQ.task = task
+  self.completed = 0
+  // make sure offset is in options for creating the idFilter below
+  task.options.offset = task.offset
+
+  var opts = {
+    layer: task.options.layer,
+    where: task.options.where,
+    idFilter: koop.Exporter.createIdFilter(task.options),
+    geometry: task.options.geometry,
+    bypassProcessing: true
+  }
+
+  var filePart = task.file
+  // TODO in koop-pgcache 2.0 this will be a geojson feature collection and not and array
+  cache.db.select(task.dbKey, opts, function (err, entry) {
+    if (err) throw err
+    if (fs.existsSync(filePart)) fs.unlinkSync(filePart)
+
+    fs.writeFile(filePart, JSON.stringify(entry[0]), function () {
+      // TODO why build this here?
+      // we could open a file handle and push each layer into the file via io
+      var vrtPartial = '<OGRVRTLayer name="OGRGeoJSON"><SrcDataSource>'
+      vrtPartial += filePart
+      vrtPartial += '</SrcDataSource></OGRVRTLayer>'
+
+      fs.appendFileSync(task.files.rootVrtFile, vrtPartial)
+      // tick up the number of complete pages
+      self.completed++
+      job.progress(null, null, pageLen)
+      cb()
+    })
+  })
+}, 4)
+
+workerQ.drain = function () {
+  var task = this.task
+  var done = task.done
+  var job = task.job
+  // close the VRT
+  fs.appendFileSync(task.files.rootVrtFile, '</OGRVRTDataSource>')
+
+  var params = {
+    inFile: task.files.rootVrtFile,
+    outFile: task.files.rootNewFile,
+    paths: task.files,
+    format: task.format
+  }
+
+  var fileLoc = path.join(path.dirname(params.inFile), 'part.0.json')
+  var geojson = JSON.parse(fs.readFileSync(fileLoc))
+  job.data.options.large = true
+
+  try {
+    koop.Exporter.callOgr(params, geojson, job.data.options, function (err, formatFile) {
+      if (err) throw err
+      var paths = {paths: task.files, file: formatFile}
+      finishExport(task.format, job.data.key, task.options, paths, done)
+    })
+  } catch (e) {
+    koop.log.error('error calling OGR2OGR', e)
+    throw e
+  }
+}
+
+/**
+ * This method is duplicate method from whats in the BaseModel.
+ * since workers are removed from koop providers we dont have access to
+ * these methods in the workers.
+ * This function finishes the export by cleaning up after it self and uploading to s3
+ *
+ * @param {string} format - the file format requested
+ * @param {string} key - a hash representing all the options applied to the data
+ * @param {object} options - options including filters applied to the data
+ * @param {object} result - the file paths resulting from a successful export
+ * @param {function} callback - calls back with an error or the file
+ * @private
+ */
 function finishExport (format, key, options, result, callback) {
   function _sendFile (err, result) {
     if (err) return callback(err)
 
-    if (koopLib.files.s3) {
+    if (files.s3) {
       try {
         // try to clean up local FS
         fs.unlinkSync(result.paths.rootJsonFile)
       } catch (e) {
-        koopLib.log.debug('Trying to remove non-existant file: %s', result.paths.rootJsonFile)
+        koop.log.debug('Trying to remove non-existant file: %s', result.paths.rootJsonFile)
       }
-      koopLib.files.exists(result.paths.path + '/' + key, result.paths.newFile, function (exists, path) {
-        if (!exists) return callback('File did not get created.', null)
+      files.exists(result.paths.path + '/' + key, result.paths.newFile, function (exists, path) {
+        if (!exists) throw new Error('File did not get created.')
         callback(null, path)
       })
     } else {
-      if (err) return callback(err, null)
+      if (err) throw err
       callback(null, result.file)
     }
   }
 
-  if (koopLib.files.s3) {
+  if (files.s3) {
     try {
       var stream = fs.createReadStream(result.file)
 
-      koopLib.files.write(result.paths.path + '/' + key, result.paths.newFile, stream, function (err) {
-        if (err) return callback(err)
+      files.write(result.paths.path + '/' + key, result.paths.newFile, stream, function (err) {
+        if (err) throw err
 
-        if (!options.isFiltered) {
-          koopLib.files.write(result.paths.latestPath, result.paths.newFile, fs.createReadStream(result.file), function (err) {
+        // only write the latest file if there has been no filters applied
+        if (!options.filtered) {
+          files.write(result.paths.latestPath, result.paths.newFile, fs.createReadStream(result.file), function (err) {
             if (err) return callback(err)
 
             try {
               fs.unlinkSync(result.paths.rootNewFile)
             } catch (e) {
-              koopLib.log.debug('Trying to remove non-existant file: ' + result.paths.rootNewFile)
+              koop.log.debug('Trying to remove non-existant file: ' + result.paths.rootNewFile)
             }
           })
         }
@@ -360,7 +357,7 @@ function finishExport (format, key, options, result, callback) {
         _sendFile(null, result)
       })
     } catch (e) {
-      console.log('Error while saving to s3', e, result.file)
+      koop.log.error('Error while saving to s3', e, result.file)
       _sendFile(null, result)
     }
   } else {

--- a/lib/Files.js
+++ b/lib/Files.js
@@ -27,7 +27,7 @@ var Files = function (options) {
   this.s3Bucket = (config.s3) ? config.s3.bucket : false
 
   /** @type {AWS.S3} s3 connection instance */
-  this.s3 = this.s3bucket ? new AWS.S3() : false
+  this.s3 = this.s3Bucket ? new AWS.S3() : false
 
   /**
    * returns the path to the file locally or on s3

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var lib = {
 
   Exporter: require('./Exporter.js'),
   Files: require('./Files.js'),
+  ExportQueue: require('./ExportQueue.js'),
 
   Logger: require('./Logger.js')
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "mocha": "^2.2.1",
     "nock": "^2.12.0",
     "should": "~5.2.0",
-    "standard": "^5.2.2"
+    "sinon": "^1.17.1",
+    "standard": "^5.3.1"
   },
   "homepage": "https://github.com/koopjs/koop",
   "keywords": [

--- a/test/models/exportJob-test.js
+++ b/test/models/exportJob-test.js
@@ -1,0 +1,139 @@
+/* globals describe, afterEach, before, after, it */
+var should = require('should')
+var config = require('config')
+var koop = require('../../')(config)
+var ExportJob = require('../../lib/ExportJob')
+var sinon = require('sinon')
+var fakeQueue = {
+  create: function (queue, options) {
+    this.queue = queue
+    this.options = options
+    return this
+  },
+  removeOnComplete: function (bool) {
+    return this
+  },
+  save: function (callback) {
+    return {
+      on: function (event, method) {
+        return null
+      }
+    }
+  }
+}
+
+var helpers = {
+  log: koop.log,
+  cache: koop.Cache,
+  queue: fakeQueue
+}
+
+var options = {
+  key: 'key',
+  table: 'table',
+  format: 'format'
+}
+
+describe('Creating a new job', function () {
+  before(function (done) {
+    sinon.stub(helpers.cache, 'updateInfo', function (table, info, callback) {
+      callback(null)
+    })
+    done()
+  })
+
+  after(function (done) {
+    helpers.cache.updateInfo.restore()
+    done()
+  })
+
+  afterEach(function (done) {
+    helpers.cache.getInfo.restore()
+    done()
+  })
+
+  it('should create a new job when the key has never been seen before', function (done) {
+    var job = new ExportJob(helpers, options, function (err, status, created) {
+      should.not.exist(err)
+      status.generating.key.progress.should.equal('0%')
+      status.generating.key.format.should.equal(true)
+      created.should.equal(true)
+      done()
+    })
+
+    sinon.stub(helpers.cache, 'getInfo', function (table, callback) {
+      callback(null, {})
+    })
+
+    job.start()
+  })
+
+  it('should create a new job when the key is finished processing and the format is new', function (done) {
+    var status = {
+      generating: {
+        key: {
+          progress: '100%'
+        }
+      }
+    }
+
+    sinon.stub(helpers.cache, 'getInfo', function (table, callback) {
+      callback(null, status)
+    })
+
+    var job = new ExportJob(helpers, options, function (err, status, created) {
+      should.not.exist(err)
+      status.generating.key.format.should.equal(true)
+      created.should.equal(true)
+      done()
+    })
+
+    job.start()
+  })
+
+  it('should not create a new job when the key is processing', function (done) {
+    var status = {
+      generating: {
+        key: {
+          progress: '50%',
+          otherFormat: true
+        }
+      }
+    }
+
+    sinon.stub(helpers.cache, 'getInfo', function (table, callback) {
+      callback(null, status)
+    })
+
+    var job = new ExportJob(helpers, options, function (err, status, created) {
+      should.not.exist(err)
+      created.should.equal(false)
+      done()
+    })
+
+    job.start()
+  })
+
+  it('should not create a new job when the format has already been requested', function (done) {
+    var status = {
+      generating: {
+        key: {
+          progress: '100%',
+          format: true
+        }
+      }
+    }
+
+    sinon.stub(helpers.cache, 'getInfo', function (table, callback) {
+      callback(null, status)
+    })
+
+    var job = new ExportJob(helpers, options, function (err, status, created) {
+      should.not.exist(err)
+      created.should.equal(false)
+      done()
+    })
+
+    job.start()
+  })
+})

--- a/test/models/exporter-test.js
+++ b/test/models/exporter-test.js
@@ -272,4 +272,3 @@ describe('exporter Model', function () {
     })
   })
 })
-

--- a/test/models/index-test.js
+++ b/test/models/index-test.js
@@ -8,7 +8,7 @@ describe('Index tests for registering providers', function () {
     it('when the provider has a pattern', function (done) {
       koop.register(provider)
       Object.keys(koop.services).length.should.equal(1)
-      koop._router.stack.length.should.equal(16)
+      koop._router.stack.length.should.equal(17)
       done()
     })
   })


### PR DESCRIPTION
This is marked DNM because it's ready for review but needs to go through integration testing.

The main goal of this refactor was to remove the ambiguous `status: processing` when a resource is being exported to a format.

Instead the info doc will look like
``` json
{
  "generating": {
    "key1": {
      "progress": "50%"
    },
    "key2": {
      "progress": "100%",
      "zip": true,
      "kml": true
    }
  }
}
```

`Progress` is created by an export job pulling rows from the database and writing them to json. The `format: true` indicates that a file format export is either in progress or has been completed. These values serve to create implicit export locks that do no allow new jobs to be created when they shouldn't be.

Also during this refactor I broke ExportWorker up into many smaller functions and removed extraneous updates of the database.

ping @koopjs/dev 