### PR TITLE
Update broken Koop Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Visit the demo at [http://koop.dc.esri.com](http://koop.dc.esri.com).
 
 ## Resources
 
-* [Koop Documentation](https://koopjs.github.io/docs)
+* [Koop Documentation](https://koopjs.github.io/docs/basics)
 * [ArcGIS REST API Documentation](http://resources.arcgis.com/en/help/arcgis-rest-api/)
 * [ArcGIS for Developers](http://developers.arcgis.com)
 * [@esri](http://twitter.com/esri)


### PR DESCRIPTION
The link resulted in a 404 before, updated the link to match the link from the top-level github.io page.