### PR TITLE
refactor(output-geoservices): remove legacy feature server routes

### DIFF
--- a/.changeset/calm-lizards-float.md
+++ b/.changeset/calm-lizards-float.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/output-geoservices': major
+---
+
+remove legacy routes

--- a/packages/koop-core/src/index.spec.js
+++ b/packages/koop-core/src/index.spec.js
@@ -43,7 +43,7 @@ describe('Index tests', function () {
       const routePaths = koop.server._router.stack
         .filter((layer) => { return _.has(layer, 'route.path'); })
         .map(layer => { return _.get(layer, 'route.path'); });
-      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'));
+      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/rest/services/:id/FeatureServer'));
       const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'));
       providerRouteIndex.should.be.below(pluginRouteIndex);
     });
@@ -55,7 +55,7 @@ describe('Index tests', function () {
       const routePaths = koop.server._router.stack
         .filter((layer) => { return _.has(layer, 'route.path'); })
         .map(layer => { return _.get(layer, 'route.path'); });
-      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'));
+      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/rest/services/:id/FeatureServer'));
       const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'));
       pluginRouteIndex.should.be.below(providerRouteIndex);
     });
@@ -196,7 +196,7 @@ describe('Index tests', function () {
       const koop = new Koop();
       koop.register(provider, { routePrefix: '/api/test' });
       request(koop.server)
-        .get('/api/test/test-provider/foo/FeatureServer')
+        .get('/api/test/test-provider/rest/services/foo/FeatureServer')
         .then((res) => {
           res.should.have.property('error', false);
           done();

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -124,12 +124,9 @@ function normalizeError (error) {
 /**
  * Collection of route objects that define geoservices
  *
- * These routes are bound to the Koop API for each provider. Note that FeatureServer,
- * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found
- * in the collection with and without the "$namespace/rest/services/$providerParams" prefix.
- * These prefixed routes have been added due to some clients requiring the "rest/services"
- * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders
- * that koop-core replaces with provider-specific settings.
+ * These routes are bound to the Koop API for each provider. $namespace and 
+ * $providerParams will be replaced by a registered providers namespace an
+ * configured parameters
  */
 Geoservices.routes = [
   {
@@ -168,42 +165,12 @@ Geoservices.routes = [
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer/:layer/:method',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/layers',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/:layer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/FeatureServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/MapServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'MapServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   }


### PR DESCRIPTION
Routes with a `/rest/services` fragment were added to the output-geoservices plugin in April of 2018 when it became clear that ArcGIS clients required them to work properly with Koop.  We left the legacy routes (those without `/rest/services`) to ensure backward compatibility.  However, having two sets of routes has created confusion for users - especially when then attempt to use the legacy routes with and ArcGIS client and get failures.  After 4 1/2 years, it seems it is a fair time to remove these routes.

BREAKING CHANGE: remove legacy feature server routes