### PR TITLE
Remove legacy geoservice routes

### DIFF
--- a/.changeset/calm-lizards-float.md
+++ b/.changeset/calm-lizards-float.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/output-geoservices': major
+---
+
+- remove FeatureServer routes that do not include `/rest/services. This is technically a breaking change but should not affect any Koop applications that are specifically used with ArcGIS clients, as they only use routes with `/rest/services`.

--- a/packages/koop-core/src/index.spec.js
+++ b/packages/koop-core/src/index.spec.js
@@ -43,7 +43,7 @@ describe('Index tests', function () {
       const routePaths = koop.server._router.stack
         .filter((layer) => { return _.has(layer, 'route.path'); })
         .map(layer => { return _.get(layer, 'route.path'); });
-      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'));
+      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/rest/services/:id/FeatureServer'));
       const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'));
       providerRouteIndex.should.be.below(pluginRouteIndex);
     });
@@ -55,7 +55,7 @@ describe('Index tests', function () {
       const routePaths = koop.server._router.stack
         .filter((layer) => { return _.has(layer, 'route.path'); })
         .map(layer => { return _.get(layer, 'route.path'); });
-      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'));
+      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/rest/services/:id/FeatureServer'));
       const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'));
       pluginRouteIndex.should.be.below(providerRouteIndex);
     });
@@ -196,7 +196,7 @@ describe('Index tests', function () {
       const koop = new Koop();
       koop.register(provider, { routePrefix: '/api/test' });
       request(koop.server)
-        .get('/api/test/test-provider/foo/FeatureServer')
+        .get('/api/test/test-provider/rest/services/foo/FeatureServer')
         .then((res) => {
           res.should.have.property('error', false);
           done();

--- a/packages/output-geoservices/README.md
+++ b/packages/output-geoservices/README.md
@@ -2,7 +2,7 @@
 
 [![npm version][npm-img]][npm-url]
 
-Wraps [FeatureServer](https://github.com/featureserver/featureserver) into a [Koop](http://koopjs.github.io) Output plugin.
+Wraps FeatureServer into a [Koop](http://koopjs.github.io) Output plugin.
 
 ## Usage
 ```js
@@ -59,42 +59,12 @@ Geoservices.routes = [
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer/:layer/:method',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/layers',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/:layer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/FeatureServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/MapServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'MapServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   }

--- a/packages/output-geoservices/package.json
+++ b/packages/output-geoservices/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@koopjs/output-geoservices",
   "version": "4.0.1",
-  "description": "Wraps https://github.com/featureserver/featureserver as a plugin for koop",
+  "description": "Wraps FeatureServer as a Koop output plugin",
   "main": "src/index.js",
   "scripts": {
     "test": "jest",

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -124,12 +124,9 @@ function normalizeError (error) {
 /**
  * Collection of route objects that define geoservices
  *
- * These routes are bound to the Koop API for each provider. Note that FeatureServer,
- * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found
- * in the collection with and without the "$namespace/rest/services/$providerParams" prefix.
- * These prefixed routes have been added due to some clients requiring the "rest/services"
- * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders
- * that koop-core replaces with provider-specific settings.
+ * These routes are bound to the Koop API for each provider. $namespace and 
+ * $providerParams will be replaced by a registered providers namespace an
+ * configured parameters
  */
 Geoservices.routes = [
   {
@@ -168,42 +165,12 @@ Geoservices.routes = [
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer/:layer/:method',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/layers',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer/:layer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'FeatureServer',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/FeatureServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'FeatureServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
     path: '$namespace/rest/services/$providerParams/MapServer*',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'MapServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   }


### PR DESCRIPTION
Same as https://github.com/koopjs/koop/pull/432 - which failed due to issue with CI/CD.