### PR TITLE
feat: allow use of custom logger

### DIFF
--- a/.changeset/cold-eyes-flow.md
+++ b/.changeset/cold-eyes-flow.md
@@ -1,0 +1,6 @@
+---
+'@koopjs/logger': major
+---
+
+- change default level to "info"
+- allow custom level to be set via configuration object

--- a/.changeset/gorgeous-schools-beam.md
+++ b/.changeset/gorgeous-schools-beam.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': minor
+---
+
+- allow use of custom logger when passed in as part of configuration object 

--- a/.changeset/sharp-boxes-suffer.md
+++ b/.changeset/sharp-boxes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/output-geoservices': minor
+---
+
+- allow custom logger from output-plugin registration options

--- a/packages/koop-core/src/provider-registration/create-controller.js
+++ b/packages/koop-core/src/provider-registration/create-controller.js
@@ -3,14 +3,14 @@ class DefaultController {}
 /**
  * We extend all controllers to ensure the following properties exist: this.model, this.routes, this.namespace
  */
-module.exports = function createController (model, BaseController = DefaultController) {
+module.exports = function createController (model, BaseController = DefaultController, options) {
   class Controller extends BaseController {
-    constructor (model) {
-      super(model);
+    constructor (model, options) {
+      super(model, options);
       this.model = model;
     }
   }
-  const controller = new Controller(model);
+  const controller = new Controller(model, options);
   const controllerEnumerables = Object.keys(BaseController).reduce((acc, member) => {
     acc[member] = BaseController[member];
     return acc;

--- a/packages/koop-core/src/provider-registration/index.js
+++ b/packages/koop-core/src/provider-registration/index.js
@@ -44,8 +44,8 @@ module.exports = class ProviderRegistration {
     this.model = createModel({ ProviderModel: provider.Model, namespace: this.namespace, koop }, options);
     this.routes = provider.routes || [];
     this.registeredOutputs = [];
-    this.outputs = koop.outputs.map(Output => {
-      return createController(this.model, Output);
+    this.outputs = koop.outputs.map(({ outputClass, options }) => {
+      return createController(this.model, outputClass, options);
     });
     this.controller = createController(this.model, provider.Controller);
   }

--- a/packages/koop-core/src/provider-registration/index.spec.js
+++ b/packages/koop-core/src/provider-registration/index.spec.js
@@ -14,7 +14,7 @@ describe('Tests for Provider', function () {
     });
     const koopMock = {
       server: serverSpy,
-      outputs: [mockOutputPlugin],
+      outputs: [{ outputClass: mockOutputPlugin }],
       cache: {
         retrieve: () => {},
         upsert: () => {}

--- a/packages/koop-core/src/provider-registration/provider-output-route.spec.js
+++ b/packages/koop-core/src/provider-registration/provider-output-route.spec.js
@@ -14,7 +14,7 @@ describe('Tests for ProviderOutputRoute', function () {
     const provider = new ProviderRegistration({
       provider: mockProviderPlugin,
       koop: {
-        outputs: [mockOutputPlugin],
+        outputs: [{ outputClass: mockOutputPlugin }],
         cache: {
           retrieve: () => {},
           upsert: () => {}

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -1,10 +1,14 @@
 const FeatureServer = require('@koopjs/featureserver');
 const koopConfig = require('config');
-const Logger = require('../../logger/src');
-const log = new Logger();
-console.log('WARNING: "/MapServer" routes will be registered, but only for specialized 404 handling in FeatureServer.');
+const Logger = require('@koopjs/logger');
+let logger = new Logger();
 
-function Geoservices () {}
+function Geoservices (model, options) {
+  this.model = model;
+  if (options.logger) {
+    logger = options.logger;
+  }
+}
 
 /**
  * Helper for sending error responses 
@@ -115,7 +119,7 @@ function normalizeError (error) {
 
   if (normalizedErrorCode === 500) {
     // Log error then make generic for response
-    log.error('error', error);
+    logger.error('error', error);
     return { message: 'Internal Server Error', code: 500};
   }
   return { message, stack, code: normalizedErrorCode };


### PR DESCRIPTION
The PR:
- fixes a bug in how the koop-logger code was being required.
- refactors setting of log-level and allows it to be set via the configuration object
- allows a custom logger to be passed into koop-core
- passes the koop-logger to all output-plugin instances