### PR TITLE
Use logger instead of console.log

### DIFF
--- a/.changeset/big-bikes-deny.md
+++ b/.changeset/big-bikes-deny.md
@@ -1,0 +1,8 @@
+---
+'@koopjs/featureserver': minor
+---
+
+- use koop or other winston-based logger instead of console
+- add a Logger singleton
+- add a public `setLogger` method that can be used to override default logger or set level
+- pass logger instance on to Winnow

--- a/.changeset/silent-crews-cheer.md
+++ b/.changeset/silent-crews-cheer.md
@@ -1,0 +1,6 @@
+---
+'@koopjs/output-geoservices': minor
+---
+
+- use koop or other winston-based logger instead of console
+- pass logger on to FeatureServer

--- a/.changeset/slow-gorillas-taste.md
+++ b/.changeset/slow-gorillas-taste.md
@@ -1,0 +1,7 @@
+---
+'@koopjs/winnow': minor
+---
+
+- use koop or other winston-based logger instead of console
+- add a Logger singleton
+- add a public `setLogger` method that can be used to override default logger or set level

--- a/package-lock.json
+++ b/package-lock.json
@@ -20818,12 +20818,12 @@
     },
     "packages/koop-core": {
       "name": "@koopjs/koop-core",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@koopjs/cache-memory": "3.0.1",
-        "@koopjs/logger": "3.0.1",
-        "@koopjs/output-geoservices": "4.0.1",
+        "@koopjs/logger": "4.0.0",
+        "@koopjs/output-geoservices": "5.1.0",
         "body-parser": "^1.19.0",
         "chalk": "^4.0.0",
         "compression": "^1.7.4",
@@ -20926,7 +20926,7 @@
     },
     "packages/logger": {
       "name": "@koopjs/logger",
-      "version": "3.0.1",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "winston": "^3.2.1"
@@ -20938,11 +20938,11 @@
     },
     "packages/output-geoservices": {
       "name": "@koopjs/output-geoservices",
-      "version": "4.0.1",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@koopjs/featureserver": "5.0.1",
-        "@koopjs/logger": "3.0.1"
+        "@koopjs/logger": "4.0.0"
       }
     },
     "packages/winnow": {
@@ -23167,8 +23167,8 @@
       "version": "file:packages/koop-core",
       "requires": {
         "@koopjs/cache-memory": "3.0.1",
-        "@koopjs/logger": "3.0.1",
-        "@koopjs/output-geoservices": "4.0.1",
+        "@koopjs/logger": "4.0.0",
+        "@koopjs/output-geoservices": "5.1.0",
         "body-parser": "^1.19.0",
         "chalk": "^4.0.0",
         "compression": "^1.7.4",
@@ -23231,7 +23231,7 @@
       "version": "file:packages/output-geoservices",
       "requires": {
         "@koopjs/featureserver": "5.0.1",
-        "@koopjs/logger": "3.0.1"
+        "@koopjs/logger": "4.0.0"
       }
     },
     "@koopjs/provider-file-geojson": {

--- a/packages/featureserver/src/helpers/calculate-extent.js
+++ b/packages/featureserver/src/helpers/calculate-extent.js
@@ -1,6 +1,6 @@
 const { calculateBounds } = require('@terraformer/spatial');
+const { logger } = require('../logger');
 const normalizeExtent = require('./normalize-extent');
-const debug = process.env.KOOP_LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'debug';
 
 function calculateExtent ({ isLayer, geojson, spatialReference }) {
   if (!isLayer) {
@@ -11,9 +11,7 @@ function calculateExtent ({ isLayer, geojson, spatialReference }) {
     const bounds = calculateBounds(geojson);
     return normalizeExtent(bounds, spatialReference);
   } catch (error) {
-    if (debug) {
-      console.log(`Could not calculate extent from data: ${error.message}`);
-    }
+    logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 

--- a/packages/featureserver/src/helpers/feature-layer-metadata.js
+++ b/packages/featureserver/src/helpers/feature-layer-metadata.js
@@ -6,6 +6,7 @@ const {
   PolygonRenderer
 } = require('./renderers');
 const { calculateBounds } = require('@terraformer/spatial');
+const { logger } = require('../logger');
 const getSpatialReference = require('./get-spatial-reference');
 const getGeometryTypeFromGeojson = require('./get-geometry-type-from-geojson');
 const normalizeExtent = require('./normalize-extent');
@@ -131,7 +132,7 @@ function calculateExtentFromFeatures (geojson, spatialReference) {
       spatialReference
     };
   } catch (error) {
-    console.log(`Could not calculate extent from data: ${error.message}`);
+    logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 

--- a/packages/featureserver/src/helpers/fields/fields.js
+++ b/packages/featureserver/src/helpers/fields/fields.js
@@ -35,7 +35,7 @@ class Fields {
     } = options;
 
     if (shouldWarnAboutMissingIdFieldDefinition(idField, fieldDefinitions)) {
-      logger.debug(`WARNING: provider's "idField" is set to ${idField}, but this field is not found in field-definitions`);
+      logger.debug(`provider's "idField" is set to ${idField}, but this field is not found in field-definitions`);
     }
 
     const normalizedIdField = idField || 'OBJECTID';

--- a/packages/featureserver/src/helpers/fields/fields.js
+++ b/packages/featureserver/src/helpers/fields/fields.js
@@ -1,11 +1,11 @@
 const _ = require('lodash');
-const chalk = require('chalk');
 const {
   ObjectIdField,
   FieldFromKeyValue,
   FieldFromFieldDefinition,
   ObjectIdFieldFromDefinition
 } = require('./field-classes');
+const { logger } = require('../../logger');
 
 class Fields {
   static normalizeOptions (inputOptions) {
@@ -35,9 +35,7 @@ class Fields {
     } = options;
 
     if (shouldWarnAboutMissingIdFieldDefinition(idField, fieldDefinitions)) {
-      console.warn(
-        chalk.yellow(`WARNING: provider's "idField" is set to ${idField}, but this field is not found in field-definitions`)
-      );
+      logger.debug(`WARNING: provider's "idField" is set to ${idField}, but this field is not found in field-definitions`);
     }
 
     const normalizedIdField = idField || 'OBJECTID';

--- a/packages/featureserver/src/helpers/get-geometry-type-from-geojson.js
+++ b/packages/featureserver/src/helpers/get-geometry-type-from-geojson.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const debug = process.env.KOOP_LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'debug';
+const { logger } = require('../logger');
 
 const esriLookup = {
   Point: 'esriGeometryPoint',
@@ -17,8 +17,8 @@ const esriLookup = {
 module.exports = function getGeometryTypeFromGeojson ({ geometryType, metadata = {}, features = [] } = {}) {
   const type = geometryType || metadata.geometryType || findInFeatures(features);
 
-  if (!type && debug) {
-    console.log(`Input JSON has unsupported geometryType: ${type}`);
+  if (!type) {
+    logger.debug(`Input JSON has unsupported geometryType: ${type}`);
   }
   return esriLookup[type];
 };

--- a/packages/featureserver/src/helpers/normalize-spatial-reference.js
+++ b/packages/featureserver/src/helpers/normalize-spatial-reference.js
@@ -99,7 +99,7 @@ function convertStringToSpatialReference (wkt) {
     const wkid = getWktWkid(wkt);
     return wktLookup.get(wkid) || esriWktLookup(wkid) || { wkt };
   } catch (err) {
-    logger.debug(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
+    logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }

--- a/packages/featureserver/src/helpers/normalize-spatial-reference.js
+++ b/packages/featureserver/src/helpers/normalize-spatial-reference.js
@@ -1,6 +1,7 @@
 const esriProjCodes = require('@esri/proj-codes');
 const Joi = require('joi');
 const wktParser = require('wkt-parser');
+const { logger } = require('../logger');
 const wktLookup = new Map();
 const schema = Joi.alternatives(
   Joi.string(),
@@ -18,9 +19,8 @@ function normalizeSpatialReference (input) {
   const { error } = schema.validate(input);
 
   if (error) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: ${input} is not a valid spatial reference; defaulting to none, error: ${error}`);
-    }
+    logger.verbose(` ${input} is not a valid spatial reference; defaulting to none, error: ${error}`);
+
     // Todo: throw error
     return { wkid: 4326, latestWkid: 4326 };
   }
@@ -81,9 +81,7 @@ function esriWktLookup (lookupValue) {
 
   if (!result) {
     // Todo - throw error
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: An unknown spatial reference was detected: ${lookupValue}; defaulting to none`);
-    }
+    logger.verbose(`An unknown spatial reference was detected: ${lookupValue}; defaulting to none`);
     return;
   }
 
@@ -101,9 +99,7 @@ function convertStringToSpatialReference (wkt) {
     const wkid = getWktWkid(wkt);
     return wktLookup.get(wkid) || esriWktLookup(wkid) || { wkt };
   } catch (err) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
-    }
+    logger.debug(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }

--- a/packages/featureserver/src/index.js
+++ b/packages/featureserver/src/index.js
@@ -1,3 +1,4 @@
+const { setLogger } = require('./logger');
 module.exports = {
   route: require('./route.js'),
   restInfo: require('./rest-info-route-handler'),
@@ -8,5 +9,6 @@ module.exports = {
   queryRelatedRecords: require('./queryRelatedRecords.js'),
   generateRenderer: require('./generate-renderer'),
   error: require('./error'),
-  authenticate: require('./authenticate')
+  authenticate: require('./authenticate'),
+  setLogger,
 };

--- a/packages/featureserver/src/logger/index.js
+++ b/packages/featureserver/src/logger/index.js
@@ -1,18 +1,17 @@
 let logger = require('./logger');
-const Logger = require('@koopjs/logger'); 
-const winnow = require('@koopjs/winnow'); 
-
+const Logger = require('@koopjs/logger');
+const winnow = require('@koopjs/winnow');
 
 module.exports = {
   logger,
-  setLogger
+  setLogger,
 };
 
 function setLogger({ logger: _logger, logLevel }) {
-  if(_logger) {
+  if (_logger) {
     logger = _logger;
     logger.silly('FeatureServer no longer using default logger.');
-    winnow.setLogger({logger});
+    winnow.setLogger({ logger });
     return;
   }
 

--- a/packages/featureserver/src/logger/index.js
+++ b/packages/featureserver/src/logger/index.js
@@ -1,0 +1,22 @@
+let logger = require('./logger');
+const Logger = require('@koopjs/logger'); 
+const winnow = require('@koopjs/winnow'); 
+
+
+module.exports = {
+  logger,
+  setLogger
+};
+
+function setLogger({ logger: _logger, logLevel }) {
+  if(_logger) {
+    logger = _logger;
+    logger.silly('FeatureServer no longer using default logger.');
+    winnow.setLogger({logger});
+    return;
+  }
+
+  if (logLevel) {
+    logger = new Logger({ logLevel });
+  }
+}

--- a/packages/featureserver/src/logger/logger.js
+++ b/packages/featureserver/src/logger/logger.js
@@ -1,0 +1,5 @@
+const Logger = require('@koopjs/logger'); 
+let _logger = new Logger();
+
+module.exports =  _logger;
+

--- a/packages/featureserver/src/query/index.js
+++ b/packages/featureserver/src/query/index.js
@@ -23,9 +23,7 @@ function query (json, requestParams = {}) {
 
   const data = (skipFiltering || !features) ? json : filterAndTransform(json, requestParams);
 
-  if (shouldLogWarnings()) {
-    logWarnings(data, requestParams.f);
-  }
+  logWarnings(data, requestParams.f);
 
   if (requestedFormat === 'geojson') {
     return {
@@ -84,10 +82,6 @@ function renderPrecalculatedData (data, {
   }
 
   return retVal;
-}
-
-function shouldLogWarnings () {
-  return process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress';
 }
 
 function renderGeoservicesResponse (data, params = {}) {

--- a/packages/featureserver/src/query/index.spec.js
+++ b/packages/featureserver/src/query/index.spec.js
@@ -266,68 +266,6 @@ describe('query', () => {
       });
       logWarningsSpy.callCount.should.equal(1);
     });
-
-    it('should not try to log warnings in production', () => {
-      const json = {
-        type: 'FeatureCollection',
-        features: [
-          {
-            properties: {
-              OBJECTID: 1138516379
-            },
-            geometry: {
-              type: 'Point',
-              coordinates: [
-                -104,
-                40
-              ]
-            }
-          }
-        ]
-      };
-
-      const params = { f: 'geojson' };
-
-      const nodeEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-      const result = queryHandler(json, params);
-      result.should.deepEqual({
-        type: 'FeatureCollection',
-        features: ['filtered-feature']
-      });
-      logWarningsSpy.callCount.should.equal(0);
-      process.env.NODE_ENV = nodeEnv;
-    });
-
-    it('should not try to log warnings when suppressed', () => {
-      const json = {
-        type: 'FeatureCollection',
-        features: [
-          {
-            properties: {
-              OBJECTID: 1138516379
-            },
-            geometry: {
-              type: 'Point',
-              coordinates: [
-                -104,
-                40
-              ]
-            }
-          }
-        ]
-      };
-
-      const params = { f: 'geojson' };
-
-      process.env.KOOP_WARNINGS = 'suppress';
-      const result = queryHandler(json, params);
-      result.should.deepEqual({
-        type: 'FeatureCollection',
-        features: ['filtered-feature']
-      });
-      logWarningsSpy.callCount.should.equal(0);
-    });
   });
 
   it('should get geometryType from json', () => {

--- a/packages/featureserver/src/query/log-warnings.js
+++ b/packages/featureserver/src/query/log-warnings.js
@@ -1,17 +1,17 @@
 const _ = require('lodash');
 const { getDataTypeFromValue } = require('../helpers');
-const chalk = require('chalk');
+const { logger } = require('../logger');
 
 function logWarnings (geojson, format) {
   const { metadata = {}, features } = geojson;
   const esriFormat = format !== geojson;
 
   if (esriFormat && !metadata.idField) {
-    console.warn(chalk.yellow('WARNING: requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. Koop will create an OBJECTID field in the absence of an "idField" assignment.'));
+    logger.debug('requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. Koop will create an OBJECTID field in the absence of an "idField" assignment.');
   }
 
   if (esriFormat && hasMixedCaseObjectIdKey(metadata.idField)) {
-    console.warn(chalk.yellow('WARNING: requested provider\'s "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.'));
+    logger.debug('WARNING: requested provider\'s "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.');
   }
 
   // Compare provider metadata fields to feature properties
@@ -46,7 +46,7 @@ function warnOnMetadataFieldDiscrepancies (metadataFields, featureProperties) {
     // look for a defined field in the features properties
     const featureField = _.find(featureFields, ['name', field.name]) || _.find(featureFields, ['name', field.alias]);
     if (!featureField || (field.type !== featureField.type && !(field.type === 'Date' && featureField.type === 'Integer') && !(field.type === 'Double' && featureField.type === 'Integer'))) {
-      console.warn(chalk.yellow(`WARNING: requested provider's metadata field "${field.name} (${field.type})" not found in feature properties)`));
+      logger.debug(`requested provider's metadata field "${field.name} (${field.type})" not found in feature properties)`);
     }
   });
 
@@ -57,7 +57,7 @@ function warnOnMetadataFieldDiscrepancies (metadataFields, featureProperties) {
 
     // Exclude warnings on feature fields named OBJECTID because OBJECTID may have been added by winnow in which case it should not be in the metadata fields array
     if (!(noNameMatch || noAliasMatch) && field.name !== 'OBJECTID') {
-      console.warn(chalk.yellow(`WARNING: requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`));
+      logger.debug(`WARNING: requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`);
     }
   });
 }

--- a/packages/featureserver/src/query/log-warnings.js
+++ b/packages/featureserver/src/query/log-warnings.js
@@ -11,7 +11,7 @@ function logWarnings (geojson, format) {
   }
 
   if (esriFormat && hasMixedCaseObjectIdKey(metadata.idField)) {
-    logger.debug('WARNING: requested provider\'s "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.');
+    logger.debug('requested provider\'s "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.');
   }
 
   // Compare provider metadata fields to feature properties
@@ -57,7 +57,7 @@ function warnOnMetadataFieldDiscrepancies (metadataFields, featureProperties) {
 
     // Exclude warnings on feature fields named OBJECTID because OBJECTID may have been added by winnow in which case it should not be in the metadata fields array
     if (!(noNameMatch || noAliasMatch) && field.name !== 'OBJECTID') {
-      logger.debug(`WARNING: requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`);
+      logger.debug(`requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`);
     }
   });
 }

--- a/packages/featureserver/src/route.js
+++ b/packages/featureserver/src/route.js
@@ -1,8 +1,8 @@
 const joi = require('joi');
 const geojsonhint = require('geojson-validation');
-const chalk = require('chalk');
 const layerInfo = require('./layer-metadata');
 const query = require('./query');
+const { logger } = require('./logger');
 const queryRelatedRecords = require('./queryRelatedRecords.js');
 const generateRenderer = require('./generate-renderer');
 const restInfo = require('./rest-info-route-handler');
@@ -64,7 +64,7 @@ module.exports = function route (req, res, geojson = {}) {
 
     return responseHandler(req, res, 200, result);
   } catch (error) {
-    if (process.env.KOOP_LOG_LEVEL === 'debug') console.trace(error);
+    logger.debug(error);
     return responseHandler(req, res, error.code || 500, { error: error.message });
   }
 };
@@ -87,15 +87,15 @@ function handleMethodRequest ({ method, geojson, req }) {
 function shouldValidateGeojson () {
   const {
     KOOP_LOG_LEVEL,
-    KOOP_DISABLE_GEOJSON_VALIDATION
+    LOG_LEVEL
   } = process.env;
-  return KOOP_LOG_LEVEL === 'debug' && KOOP_DISABLE_GEOJSON_VALIDATION !== 'true';
+  return LOG_LEVEL === 'debug' || KOOP_LOG_LEVEL === 'debug';
 }
 
 function validateGeojson (geojson, path) {
   const geojsonErrors = geojsonhint.valid(geojson, true);
   if (geojsonErrors.length > 0) {
-    console.log(chalk.yellow(`WARNING: source data for ${path} contains invalid GeoJSON; ${geojsonErrors[0]}`));
+    logger.debug(`Source data for ${path} contains invalid GeoJSON; ${geojsonErrors[0]}`);
   }
 }
 

--- a/packages/featureserver/src/route.spec.js
+++ b/packages/featureserver/src/route.spec.js
@@ -8,14 +8,9 @@ describe('Route module unit tests', () => {
     const hintSpy = sinon.spy(() => {
       return ['validatation error'];
     });
-    const chalkSpy = sinon.spy();
-
     const route = proxyquire('./route', {
       'geojson-validation': {
         valid: hintSpy
-      },
-      chalk: {
-        yellow: chalkSpy
       },
       './rest-info-route-handler': function () {},
       './response-handler': function () {}
@@ -26,21 +21,10 @@ describe('Route module unit tests', () => {
       route({ params: {}, query: {}, url: '/rest/info' }, {}, { foo: 'geojson' });
       hintSpy.calledOnce.should.equal(true);
       hintSpy.firstCall.args.should.deepEqual([{ foo: 'geojson' }, true]);
-      chalkSpy.calledOnce.should.equal(true);
-    });
-
-    it('should not validate geojson when KOOP_LOG_LEVEL === debug and KOOP_DISABLE_GEOJSON_VALIDATION = true', () => {
-      process.env.KOOP_LOG_LEVEL = 'debug';
-      process.env.KOOP_DISABLE_GEOJSON_VALIDATION = 'true';
-      route({ params: {}, query: {}, url: '/rest/info' }, {}, { foo: 'geojson' });
-      hintSpy.notCalled.should.equal(true);
-      hintSpy.resetHistory();
-      chalkSpy.resetHistory();
     });
 
     afterEach(() => {
       hintSpy.resetHistory();
-      chalkSpy.resetHistory();
       process.env.KOOP_LOG_LEVEL = undefined;
       process.env.KOOP_DISABLE_GEOJSON_VALIDATION = undefined;
     });

--- a/packages/featureserver/src/server-info-route-handler.js
+++ b/packages/featureserver/src/server-info-route-handler.js
@@ -7,12 +7,12 @@ const {
   normalizeSpatialReference,
   normalizeInputData
 } = require('./helpers');
+const { logger } = require('./logger');
 const { serverMetadata: serverMetadataDefaults } = require('./defaults');
 const {
   CURRENT_VERSION,
   FULL_VERSION
 } = require('./constants');
-const debug = process.env.KOOP_LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'debug';
 
 function serverMetadata (json, req = {}) {
   const {
@@ -91,9 +91,7 @@ function calculateServiceExtentFromLayers (layers, spatialReference) {
       spatialReference
     };
   } catch (error) {
-    if (debug) {
-      console.log(`Could not calculate extent from data: ${error.message}`);
-    }
+    logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 

--- a/packages/koop-core/README.md
+++ b/packages/koop-core/README.md
@@ -6,6 +6,85 @@
 
 This is the core dependency for setting up a Koop instance.  By default it includes the Output-Geoservices plugin and an in-memory data cache.
 
+## Install
+```bash
+# Install Koop npm and save to package.json
+npm install --save @koopjs/koop-core
+```
+
+## Usage
+
+The Koop [usage docs](https://koopjs.github.io/docs/usage/koop-core) and [quick start](https://koopjs.github.io/docs/basics/quickstart) provide usage information, but we'll give a quick overview here.
+
+```js
+// require koop-core
+const Koop = require('@koopjs/koop-core')
+
+// create a Koop instance
+const koop = new Koop(options)
+
+/* Register Koop data providers */
+const provider = require('@koopjs/provider-github')
+koop.register(provider)
+
+
+// Start listening on port 8080
+koop.server.listen(8080, () => console.log(`Koop listening on port 8080!`))
+```
+
+Every Koop instance includes the Geoservice output-plugin by default, so after startup noted above, you would have the following routes ready to receive requests:
+[GET, POST] /github/rest/info
+[GET, POST] /github/rest/services/:id/FeatureServer/:layer/:method
+[GET, POST] /github/rest/services/:id/FeatureServer/layers
+[GET, POST] /github/rest/services/:id/FeatureServer/:layer
+[GET, POST] /github/rest/services/:id/FeatureServer
+
+### Options
+You can pass an `options` object when instantiating a Koop instance. 
+
+```js
+// create a Koop instance
+const koop = new Koop(options)
+```
+
+#### disableCors
+Koop enables CORS by default.  If you do not want CORS enabled, you can disable it by adding a `disableCors` boolean to your Koop config file:
+
+```js
+const options = {
+  disableCors: true
+}
+```
+
+#### disableCompression
+Koop adds Express compression by default.  If you do not want Express compression (e.g., perhaps you are using Nginx for compression), you can disable it by adding a `disableCompression` boolean to your Koop config file:
+
+```js
+const options = {
+  disableCompression: true
+}
+```
+
+#### logger
+Koop includes a Winston logger with a console transport by default.  If you have a custom logger that you want to use, you can pass it as an option:
+
+```js
+
+const logger = require('my-logger')
+const options = {
+  logger
+}
+```
+
+#### logLevel
+The default Koop logger uses a log-level of `info`.  If you want to change the log level, you can pass any of the standard Winston log-level values as an option:
+
+```js
+const options = {
+  logLevel: 'debug'
+}
+```
+
 ## Issues
 
 Find a bug or want to request a new feature? Please let us know by submitting an [issue](https://github.com/koopjs/koop/issues).

--- a/packages/koop-core/src/index.js
+++ b/packages/koop-core/src/index.js
@@ -12,9 +12,11 @@ const ProviderRegistration = require('./provider-registration');
 const middleware = require('./middleware');
 const geoservices = require('../../output-geoservices/src');
 
-function Koop (config) {
+function Koop (options) {
   this.version = pkg.version;
-  this.config = config || require('config');
+
+  // TODO: remove usage of "config" module
+  this.config = options || require('config');
   this.server = initServer(this.config);
 
   // default to in-memory cache; another cache registration overrides this
@@ -37,7 +39,7 @@ Util.inherits(Koop, Events);
 /**
  * express middleware setup
  */
-function initServer (config) {
+function initServer (options) {
   const app = express()
   // parse application/json
     .use(bodyParser.json({ limit: '10000kb' }))
@@ -53,11 +55,16 @@ function initServer (config) {
     .set('view engine', 'ejs')
     .use(express.static(path.join(__dirname, '/public')));
 
-  // Use CORS unless explicitly disable in the config
-  if (!config.disableCors) app.use(cors());
+  // Use CORS unless explicitly disabled in the config
+  if (!options.disableCors) {
+    app.use(cors());
+  }
 
   // Use compression unless explicitly disable in the config
-  if (!config.disableCompression) app.use(compression());
+  if (!options.disableCompression) {
+    app.use(compression());
+  }
+
   return app;
 }
 

--- a/packages/koop-core/src/provider-registration/create-model.js
+++ b/packages/koop-core/src/provider-registration/create-model.js
@@ -17,6 +17,7 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       this.cacheRetrieve = promisify(this.cache.retrieve).bind(this.cache);
       this.cacheUpsert = promisify(this.cache.upsert).bind(this.cache);
       this.getData = promisify(this.getData).bind(this);
+      this.logger = koop.log;
     }
 
     async pull (req, callback) {
@@ -26,10 +27,9 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
         const cached = await this.cacheRetrieve(key, req.query);
         if (isFresh(cached)) return callback(null, cached);
       } catch (err) {
-        if (process.env.KOOP_LOG_LEVEL === 'debug') {
-          console.log(err);
-        }
+        this.logger.debug(err);
       }
+      
       try {
         await this.before(req);
         const providerGeojson = await this.getData(req);

--- a/packages/koop-core/src/provider-registration/create-model.spec.js
+++ b/packages/koop-core/src/provider-registration/create-model.spec.js
@@ -10,6 +10,10 @@ const koopMock = {
   cache: {
     retrieve () {},
     upsert () {}
+  },
+  log: {
+    debug: () => {},
+    info: () => {}
   }
 };
 
@@ -185,6 +189,10 @@ describe('Tests for create-model', function () {
         authenticate: () => {},
         authorize: () => {},
         authenticationSpecification: sinon.spy()
+      },
+      log: {
+        debug: () => {},
+        info: () => {}
       }
     };
 

--- a/packages/koop-core/src/provider-registration/index.js
+++ b/packages/koop-core/src/provider-registration/index.js
@@ -1,5 +1,3 @@
-const chalk = require('chalk');
-const Table = require('easy-table');
 const _ = require('lodash');
 const Joi = require('joi');
 const createController = require('./create-controller');
@@ -48,6 +46,7 @@ module.exports = class ProviderRegistration {
       return createController(this.model, outputClass, options);
     });
     this.controller = createController(this.model, provider.Controller);
+    this.logger = koop.log;
   }
 
   registerRoutes (server) {
@@ -111,8 +110,6 @@ module.exports = class ProviderRegistration {
   }
 
   logRoutes () {
-    if (process.env.NODE_ENV === 'test' || process.env.KOOP_DISABLE_CONSOLE_ROUTES === 'true') return;
-
     if (this.registerOutputRoutesFirst) {
       this.logOutputDefinedRoutes();
       this.logProviderDefinedRoutes();
@@ -123,24 +120,20 @@ module.exports = class ProviderRegistration {
   }
 
   logProviderDefinedRoutes () {
-    const table = new Table();
+    if (this.registeredProviderRoutes > 0) {
+      this.logger.info(`[${this.namespace}] custom routes`);
+    }
     this.registeredProviderRoutes.forEach(route => {
-      table.cell(chalk.cyan(`"${this.namespace}" provider routes`), chalk.yellow(route.registeredPath));
-      table.cell(chalk.cyan('Methods'), chalk.green(route.methods.join(', ').toUpperCase()));
-      table.newRow();
+      this.logger.info(`ROUTE | [${route.methods.join(', ').toUpperCase()}] | ${route.registeredPath}`);
     });
-    console.log(`\n${table.toString()}`);
   }
 
   logOutputDefinedRoutes () {
     this.registeredOutputs.forEach(output => {
-      const table = new Table();
+      this.logger.info(`[${output.namespace}] routes for [${this.namespace}] provider`);
       output.routes.forEach(route => {
-        table.cell(chalk.cyan(`"${output.namespace}" output routes for the "${this.namespace}" provider`), chalk.yellow(route.registeredPath));
-        table.cell(chalk.cyan('Methods'), chalk.green(route.methods.join(', ').toUpperCase()));
-        table.newRow();
+        this.logger.info(`ROUTE | [${route.methods.join(', ').toUpperCase()}] | ${route.registeredPath}`);
       });
-      console.log(`\n${table.toString()}`);
     });
   }
 };

--- a/packages/koop-core/src/provider-registration/index.spec.js
+++ b/packages/koop-core/src/provider-registration/index.spec.js
@@ -18,6 +18,10 @@ describe('Tests for Provider', function () {
       cache: {
         retrieve: () => {},
         upsert: () => {}
+      },
+      log: {
+        debug: () => {},
+        info: () => {}
       }
     };
     const providerRegistration = ProviderRegistration.create({ koop: koopMock, provider: { ...mockProviderPlugin, hosts: true } });

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -7,7 +7,7 @@ function Geoservices (model, options) {
   this.model = model;
   if (options.logger) {
     logger = options.logger;
-    //FeatureServer.setLogger({logger});
+    FeatureServer.setLogger({logger});
   }
 }
 

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -7,6 +7,7 @@ function Geoservices (model, options) {
   this.model = model;
   if (options.logger) {
     logger = options.logger;
+    //FeatureServer.setLogger({logger});
   }
 }
 

--- a/packages/winnow/benchmark/index.js
+++ b/packages/winnow/benchmark/index.js
@@ -1,5 +1,3 @@
-process.env.KOOP_WARNINGS = 'suppress';
-
 const Benchmark = require('benchmark');
 const fs = require('fs-extra');
 const path = require('path');

--- a/packages/winnow/src/filter-and-transform/transforms/project.js
+++ b/packages/winnow/src/filter-and-transform/transforms/project.js
@@ -1,3 +1,4 @@
+const { logger } = require('../../logger');
 const projectCoordinates = require('../../helpers/project-coordinates');
 
 function project (geometry, sourceCoordinateSystem, targetCoordinateSystem) {
@@ -21,15 +22,10 @@ function tryProjectingGeometry ({ type, sourceCoordinates, sourceCoordinateSyste
       })
     };
   } catch (error) {
-    if (shouldLogProjectError()) console.error(error);
+    logger.debug(error);
     // TODO: should we throw error instead of returning null?
     return null;
   }
-}
-
-function shouldLogProjectError () {
-  if (process.env.KOOP_LOG_LEVEL === 'debug') return true;
-  return process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress';
 }
 
 module.exports = project;

--- a/packages/winnow/src/filter-and-transform/transforms/project.spec.js
+++ b/packages/winnow/src/filter-and-transform/transforms/project.spec.js
@@ -3,7 +3,6 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const project = require('./project');
 const modulePath = './project';
-process.env.KOOP_WARNINGS = 'suppress';
 
 test('project, empty input, returns undefined', t => {
   const result = project();

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { logger } = require('../../logger');
 const { createIntegerHash } = require('../helpers');
 
 module.exports = function transformToEsriProperties (inputProperties, geometry, delimitedDateFields, requiresObjectId, idField) {
@@ -10,8 +11,10 @@ module.exports = function transformToEsriProperties (inputProperties, geometry, 
 
   if (requiresObjectId && !idField) {
     return injectObjectId({ properties, geometry });
-  } else if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
-    console.warn(`WARNING: OBJECTIDs created from provider's "idField" (${idField}: ${inputProperties[idField]}) are not integers from 0 to 2147483647`);
+  }
+  
+  if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
+    logger.debug(`OBJECTIDs created from provider's "idField" (${idField}: ${inputProperties[idField]}) are not integers from 0 to 2147483647`);
   }
 
   return properties;
@@ -27,9 +30,7 @@ function injectObjectId (feature) {
 }
 
 function shouldLogIdFieldWarning (idField) {
-  return process.env.NODE_ENV !== 'production' &&
-    process.env.KOOP_WARNINGS !== 'suppress' &&
-    (!Number.isInteger(idField) || idField > 2147483647);
+  return (!Number.isInteger(idField) || idField > 2147483647);
 }
 
 function transformProperties (properties, dateFields) {

--- a/packages/winnow/src/index.js
+++ b/packages/winnow/src/index.js
@@ -1,4 +1,4 @@
-//const { setLogger } = require('./logger');
+const { setLogger } = require('./logger');
 
 const {
   filterAndTransform,
@@ -11,5 +11,5 @@ module.exports = {
   prepareQuery,
   querySql: filterAndTransform,
   prepareSql: prepareFilterAndTransform,
-  // setLogger
+  setLogger
 };

--- a/packages/winnow/src/index.js
+++ b/packages/winnow/src/index.js
@@ -1,11 +1,15 @@
+//const { setLogger } = require('./logger');
+
 const {
   filterAndTransform,
   prepareFilterAndTransform,
 } = require('./filter-and-transform');
 const { query, prepareQuery } = require('./query');
+
 module.exports = {
   query,
   prepareQuery,
   querySql: filterAndTransform,
   prepareSql: prepareFilterAndTransform,
+  // setLogger
 };

--- a/packages/winnow/src/logger/index.js
+++ b/packages/winnow/src/logger/index.js
@@ -1,0 +1,19 @@
+let logger  = require('./logger');
+const Logger = require('@koopjs/logger'); 
+
+module.exports = {
+  logger,
+  setLogger
+};
+
+function setLogger({ logger: _logger, logLevel }) {
+  if(_logger) {
+    logger = _logger;
+    logger.silly('Winnow no longer using default logger.');
+    return;
+  }
+
+  if (logLevel) {
+    logger = new Logger({ logLevel });
+  }
+}

--- a/packages/winnow/src/logger/index.js
+++ b/packages/winnow/src/logger/index.js
@@ -1,13 +1,13 @@
-let logger  = require('./logger');
-const Logger = require('@koopjs/logger'); 
+let logger = require('./logger');
+const Logger = require('@koopjs/logger');
 
 module.exports = {
   logger,
-  setLogger
+  setLogger,
 };
 
 function setLogger({ logger: _logger, logLevel }) {
-  if(_logger) {
+  if (_logger) {
     logger = _logger;
     logger.silly('Winnow no longer using default logger.');
     return;

--- a/packages/winnow/src/logger/logger.js
+++ b/packages/winnow/src/logger/logger.js
@@ -1,0 +1,6 @@
+const Logger = require('@koopjs/logger'); 
+let _logger = new Logger();
+
+
+module.exports =  _logger;
+

--- a/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
@@ -16,7 +16,7 @@ function normalizeGeometryFilterSpatialReference (options = {}) {
   const spatialReference = normalizeSpatialReference(geometryEnvelopeSpatialReference || options.inSR);
 
   if (!spatialReference) {
-    logger.debug('WARNING: geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
+    logger.debug('geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
   }
   return spatialReference || { wkid: 4326 };
 }

--- a/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
+const { logger } = require('../logger');
 const { normalizeArray } = require('./helpers');
 const normalizeSpatialReference = require('./spatial-reference');
-const logWarning = process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress';
 
 /**
  * Normalize the input spatial reference for a geometry filter. Look on options.geometry object first.
@@ -15,8 +15,9 @@ function normalizeGeometryFilterSpatialReference (options = {}) {
 
   const spatialReference = normalizeSpatialReference(geometryEnvelopeSpatialReference || options.inSR);
 
-  if (!spatialReference && logWarning) console.log('WARNING: geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
-
+  if (!spatialReference) {
+    logger.debug('WARNING: geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
+  }
   return spatialReference || { wkid: 4326 };
 }
 

--- a/packages/winnow/src/normalize-query-options/id-field.js
+++ b/packages/winnow/src/normalize-query-options/id-field.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { logger } = require('../logger');
 /**
  * Ensure idField is set if metadata doesn't have a value but a field named OBJECTID is present
  * @param {object} metadata
@@ -8,7 +9,7 @@ function normalizeIdField (options, features = []) {
   const idField = extractIdField(metadata, features[0]);
 
   if (shouldWarnIdFieldIsMissingFromData(idField, features)) {
-    console.warn('WARNING: requested provider has "idField" assignment, but this property is not found in properties of all features.');
+    logger.debug('requested provider has "idField" assignment, but this property is not found in properties of all features.');
   }
 
   return idField;
@@ -27,7 +28,10 @@ function extractIdField ({ idField, fields } = {}, feature = {}) {
 }
 
 function shouldWarnIdFieldIsMissingFromData (idField, features) {
-  if (process.env.NODE_ENV === 'production' || process.env.KOOP_WARNINGS === 'suppress' || !idField || features.length === 0) return;
+  if (!idField || features.length === 0) {
+    return;
+  }
+
   const propertiesFromFirstFeature = _.get(features, '[0].properties') || _.get(features, '[0].attributes', {});
   return propertiesFromFirstFeature[idField] === undefined;
 }

--- a/packages/winnow/src/normalize-query-options/limit.js
+++ b/packages/winnow/src/normalize-query-options/limit.js
@@ -1,20 +1,22 @@
+const { logger } = require('../logger');
+
 /**
  * Normalize the limit option; defaults to undefined
  * @param {object} options
  * @returns {integer} or undefined
  */
-function normalizeLimit (options) {
+function normalizeLimit(options) {
   const limit = getLimitFromOptions(options);
 
   if (limit !== undefined && !Number.isInteger(limit)) {
-    console.warn('"limit" option is not an integer; skipping');
+    logger.debug('"limit" option is not an integer; skipping');
     return;
   }
   // If there is a limit, add 1 to it so we can later calculate a limitExceeded. The result set will be resized accordingly, post SQL
   return limit ? limit + 1 : undefined;
 }
 
-function getLimitFromOptions (options) {
+function getLimitFromOptions(options) {
   if (options.limit !== undefined) return options.limit;
 
   if (options.resultRecordCount !== undefined) return options.resultRecordCount;

--- a/packages/winnow/src/normalize-query-options/output-data-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/output-data-spatial-reference.js
@@ -1,6 +1,6 @@
 const normalizeSpatialReference = require('./spatial-reference');
 const { getCollectionCrs } = require('./helpers');
-const logWarning = process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress';
+const { logger } = require('../logger');
 
 function normalizeOutputDataSpatialReference (options = {}) {
   const {
@@ -19,7 +19,10 @@ function normalizeOutputDataSpatialReference (options = {}) {
 
   const spatialReference = normalizeSpatialReference(outputSpatialReference);
 
-  if (!spatialReference && logWarning) console.log(`WARNING: spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
+  if (!spatialReference) {
+    logger.debug(`spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
+    // @TODO: throw error
+  }
 
   return spatialReference || { wkid: 4326 };
 }

--- a/packages/winnow/src/normalize-query-options/source-data-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/source-data-spatial-reference.js
@@ -1,6 +1,6 @@
 const normalizeSpatialReference = require('./spatial-reference');
-const logWarning = process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress';
 const { getCollectionCrs } = require('./helpers');
+const { logger } = require('../logger');
 
 function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection } = {}) {
   const sourceDataSpatialReference = inputCrs || sourceSR || getCollectionCrs(collection);
@@ -8,8 +8,10 @@ function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection }
 
   const spatialReference = normalizeSpatialReference(sourceDataSpatialReference);
 
-  if (!spatialReference && logWarning) console.log(`WARNING: spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
-
+  if (!spatialReference) {
+    logger.debug(`spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
+    // @TODO: throw error?
+  }
   return spatialReference || { wkid: 4326 };
 }
 

--- a/packages/winnow/src/normalize-query-options/spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/spatial-reference.js
@@ -1,6 +1,7 @@
 const esriProjCodes = require('@esri/proj-codes');
 const Joi = require('joi');
 const wktParser = require('wkt-parser');
+const { logger } = require('../logger');
 const PROJ4_WKIDS = [4326, 4269, 3857, 3785, 900913, 102113];
 const wktLookup = new Map();
 const schema = Joi.alternatives(
@@ -20,9 +21,7 @@ function normalizeSpatialReference (input) {
   const { error } = schema.validate(input);
 
   if (error) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: ${input} is not a valid spatial reference; defaulting to none`);
-    }
+    logger.debug(`WARNING: ${input} is not a valid spatial reference; defaulting to none`);
     // Todo: throw error
     return;
   }
@@ -94,9 +93,7 @@ function esriWktLookup (wkid) {
 
   if (!result) {
     // Todo - throw error
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: An unknown spatial reference was detected: ${wkid}; defaulting to none`);
-    }
+    logger.debug(`An unknown spatial reference was detected: ${wkid}; defaulting to none`);
     return;
   }
 
@@ -117,9 +114,7 @@ function convertStringToSpatialReference (wkt) {
       wkid: wkid ? Number(wkid) : undefined
     };
   } catch (err) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
-    }
+    logger.debug(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }

--- a/packages/winnow/src/normalize-query-options/spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/spatial-reference.js
@@ -21,7 +21,7 @@ function normalizeSpatialReference (input) {
   const { error } = schema.validate(input);
 
   if (error) {
-    logger.debug(`WARNING: ${input} is not a valid spatial reference; defaulting to none`);
+    logger.debug(`${input} is not a valid spatial reference; defaulting to none`);
     // Todo: throw error
     return;
   }
@@ -114,7 +114,7 @@ function convertStringToSpatialReference (wkt) {
       wkid: wkid ? Number(wkid) : undefined
     };
   } catch (err) {
-    logger.debug(`WARNING: An un-parseable WKT spatial reference was detected: ${wkt}`);
+    logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -10,7 +10,8 @@ describe('koop', () => {
       const response = await request(koop.server).get('/file-geojson/rest/services/polygon/FeatureServer/0/query');
       expect(response.status).toBe(200);
     } catch (error) {
-      fail(error);
+      console.error(error);
+      throw error;
     }
   });
 });


### PR DESCRIPTION
- stop use of console log
- stop use of ENV vars to determine if things get logged; instead use `debug` method
- add a Logger singleton to FeatureServer and Winnow packages
- add a public `setLogger` method to FeatureServer and Winnow packages that can be used to override default logger or set log level
- have geoservice-output-plugin pass on its logger to FeatureServer
- have FeatureServer pass on its logger to Winnow
- add koop-core docs that show logger usage