### PR TITLE
feat(): support explicit options argument in provider Model constructor

### DIFF
--- a/.changeset/hot-dots-doubt.md
+++ b/.changeset/hot-dots-doubt.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': minor
+---
+
+- support explicit options argument in provider Model constructor

--- a/packages/koop-core/src/provider-registration/create-model.js
+++ b/packages/koop-core/src/provider-registration/create-model.js
@@ -7,11 +7,11 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
   class Model extends ProviderModel {
     constructor (koop, options) {
       // Merging the koop object into options to preserve backward compatibility; consider removing in future major release
-      const modelOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value();
-      super(modelOptions);
+      const mergedKoopOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value();
+      super(mergedKoopOptions, options);
       // Provider constructor's may assign values to this.cache and this.options; so check before assigning defaults
       if (!this.cache) this.cache = options.cache || koop.cache;
-      if (!this.options) this.options = modelOptions;
+      if (!this.options) this.options = mergedKoopOptions;
       this.before = promisify(options.before || before);
       this.after = promisify(options.after || after);
       this.cacheRetrieve = promisify(this.cache.retrieve).bind(this.cache);

--- a/packages/koop-core/src/provider-registration/create-model.js
+++ b/packages/koop-core/src/provider-registration/create-model.js
@@ -6,12 +6,14 @@ const after = (req, data, callback) => { callback(null, data); };
 module.exports = function createModel ({ ProviderModel, koop, namespace }, options = {}) {
   class Model extends ProviderModel {
     constructor (koop, options) {
-      // Merging the koop object into options to preserve backward compatibility; consider removing in future major release
-      const mergedKoopOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value();
-      super(mergedKoopOptions, options);
+      // Merging the koop object into options to preserve backward compatibility
+      // This should be removed in future major release now that registration 
+      // options are passed as separate arg
+      const koopAndOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value();
+      super(koopAndOptions, options);
       // Provider constructor's may assign values to this.cache and this.options; so check before assigning defaults
       if (!this.cache) this.cache = options.cache || koop.cache;
-      if (!this.options) this.options = mergedKoopOptions;
+      if (!this.options) this.options = koopAndOptions;
       this.before = promisify(options.before || before);
       this.after = promisify(options.after || after);
       this.cacheRetrieve = promisify(this.cache.retrieve).bind(this.cache);

--- a/packages/koop-core/src/provider-registration/create-model.spec.js
+++ b/packages/koop-core/src/provider-registration/create-model.spec.js
@@ -18,6 +18,23 @@ const koopMock = {
 };
 
 describe('Tests for create-model', function () {
+  describe('model constructor', () => {
+    it('should receive expected arguments', () => {
+      class Model extends providerMock.Model {
+        constructor(koop, options) {
+          super(koop, options);
+          this.koop = koop;
+          this.options = options;
+        }
+      }
+      const model = createModel({ ProviderModel: Model, koop: koopMock }, {
+        foo: 'bar'
+      });
+      model.koop.should.deepEqual({...koopMock, foo: 'bar' });
+      model.options.should.deepEqual({ foo: 'bar' });
+    });
+  });
+
   describe('model pull method', () => {
     it('should work in callback form, no upsert to cache', (done) => {
       const beforeSpy = sinon.spy((req, beforeCallback) => {
@@ -547,7 +564,7 @@ describe('Tests for create-model', function () {
       providerMock.Model.prototype.getStream = getStreamSpy;
     });
 
-    after(function () {
+    afterEach(function () {
       // reset the getStream() function to default
       providerMock.Model.prototype.getStream = undefined;
     });


### PR DESCRIPTION
Makes the provider registration `options` object explicitly available on the provider's Model constructor.