### PR TITLE
fix: set hasZ from feature metadata in query handler

### DIFF
--- a/.changeset/fresh-chefs-destroy.md
+++ b/.changeset/fresh-chefs-destroy.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': minor
+---
+
+set hasZ from feature metadata in query handler

--- a/packages/featureserver/src/query/render-features.js
+++ b/packages/featureserver/src/query/render-features.js
@@ -30,7 +30,7 @@ function renderFeaturesResponse(data = {}, params = {}) {
     objectIdFieldName: objectIdFieldNameDefault,
   } = template;
 
-  const { metadata: { limitExceeded, transform, idField } = {} } = data;
+  const { metadata: { limitExceeded, transform, idField, hasZ } = {} } = data;
 
   const computedProperties = {
     geometryType: params.geometryType,
@@ -43,6 +43,7 @@ function renderFeaturesResponse(data = {}, params = {}) {
       ...uniqueIdFieldDefault,
       name: idField || uniqueIdFieldDefault.name,
     },
+    hasZ: !!hasZ,
   };
 
   if (transform) {

--- a/packages/featureserver/src/query/render-features.spec.js
+++ b/packages/featureserver/src/query/render-features.spec.js
@@ -91,7 +91,8 @@ describe('renderFeaturesResponse', () => {
       metadata: {
         limitExceeded: true,
         transform: 'transform',
-        idField: 'hello_world'
+        idField: 'hello_world',
+        hasZ: true
       },
       type: 'FeatureCollection',
       features: [
@@ -125,7 +126,7 @@ describe('renderFeaturesResponse', () => {
       },
       geometryType: 'esriGeometryPoint',
       globalIdFieldName: '',
-      hasZ: false,
+      hasZ: true,
       hasM: false,
       spatialReference: { wkid: 1234 },
       fields: 'fields',


### PR DESCRIPTION
This sets `hasZ` in the query response based on the feature metadata from the provider model, defaulting to false to maintain previous behavior if `metadata.hasZ` is not set.

Fixes #452