### PR TITLE
fix(): use new cache info when available

### DIFF
--- a/.changeset/plenty-cobras-repair.md
+++ b/.changeset/plenty-cobras-repair.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': patch
+---
+
+- use new \_cache metadata property when available

--- a/packages/koop-core/coverage.svg
+++ b/packages/koop-core/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.17%">
-  <title>coverage: 92.17%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.55%">
+  <title>coverage: 92.55%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.17%</text>
-    <text x="648" y="138" textLength="440">92.17%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.55%</text>
+    <text x="648" y="138" textLength="440">92.55%</text>
   </g>
   
 </svg>

--- a/packages/koop-core/src/provider-registration/create-model.js
+++ b/packages/koop-core/src/provider-registration/create-model.js
@@ -35,7 +35,7 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       }
       
       try {
-        await this.before(req); 
+        await this.before(req);
         const providerGeojson = await this.getData(req);
         const afterFuncGeojson = await this.after(req, providerGeojson);
         const { ttl } = afterFuncGeojson;

--- a/packages/koop-core/src/provider-registration/create-model.js
+++ b/packages/koop-core/src/provider-registration/create-model.js
@@ -27,13 +27,15 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
 
       try {
         const cached = await this.cacheRetrieve(key, req.query);
-        if (isFresh(cached)) return callback(null, cached);
+        if (isFresh(cached)) {
+          return callback(null, cached);
+        }
       } catch (err) {
         this.logger.debug(err);
       }
       
       try {
-        await this.before(req);
+        await this.before(req); 
         const providerGeojson = await this.getData(req);
         const afterFuncGeojson = await this.after(req, providerGeojson);
         const { ttl } = afterFuncGeojson;
@@ -114,9 +116,12 @@ function createKey (req) {
   return key;
 }
 
-function isFresh (geojson) {
-  // TODO: if the cache plugin developer forgets to set the metadata.expires,
-  // the data will be forever fresh. This should be fixed.
-  if (!geojson || !geojson.metadata || !geojson.metadata.expires) return true;
-  else return Date.now() < geojson.metadata.expires;
+function isFresh ({_cache, metadata}) {
+  // older cache plugins stored cache timing in "metadata"
+  const cacheMetadata = _cache || metadata || {};
+  if (!cacheMetadata?.expires) {
+    return true;
+  }
+  
+  return Date.now() < cacheMetadata.expires;
 }


### PR DESCRIPTION
Updates the model.pull method to use new cache metadata property `_cache` when available.