### PR TITLE
fix: wrap FeatureServer errors according to ArcGIS spec

### DIFF
--- a/.changeset/nervous-panthers-exist.md
+++ b/.changeset/nervous-panthers-exist.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- wrap errors like ArcGIS server

--- a/demo/provider-data/point-fc.geojson
+++ b/demo/provider-data/point-fc.geojson
@@ -1,0 +1,49 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "fields": [
+      { "name": "timestamp", "type": "Date" } 
+      ]
+    },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "timestamp": "2023-04-10T16:15:30.000Z"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -104.9476,
+          39.9448
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "timestamp": "2020-04-10T16:15:30.000Z"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -104.9476,
+          39.9448
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "timestamp": "2015-04-10T16:15:30.000Z"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -104.9476,
+          39.9448
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13747,6 +13747,11 @@
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
+    "node_modules/js-sql-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/js-sql-parser/-/js-sql-parser-1.4.1.tgz",
+      "integrity": "sha512-J8zi3+/yK4FWSnVvLOjS2HIGfJhR6v7ApwIF8gZ/SpaO/tFIDlsgugD6ZMn6flXiuMsCjJxvhE0+xBgbdzvDDw=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -23082,6 +23087,7 @@
         "alasql": "^3.0.0",
         "classybrew": "0.0.3",
         "joi": "^17.6.3",
+        "js-sql-parser": "^1.4.1",
         "lodash": "^4.17.4",
         "moment": "^2.18.1",
         "ngeohash": "^0.6.3",
@@ -25375,6 +25381,7 @@
         "farmhash": "^3.1.0",
         "fs-extra": "^11.0.0",
         "joi": "^17.6.3",
+        "js-sql-parser": "^1.4.1",
         "lodash": "^4.17.4",
         "moment": "^2.18.1",
         "ngeohash": "^0.6.3",
@@ -33734,6 +33741,11 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
+    },
+    "js-sql-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/js-sql-parser/-/js-sql-parser-1.4.1.tgz",
+      "integrity": "sha512-J8zi3+/yK4FWSnVvLOjS2HIGfJhR6v7ApwIF8gZ/SpaO/tFIDlsgugD6ZMn6flXiuMsCjJxvhE0+xBgbdzvDDw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "packages/koop-core"
   ],
   "devDependencies": {
+    "@babel/eslint-parser": "^7.11.0",
     "@changesets/changelog-git": "^0.1.13",
     "@changesets/cli": "^2.25.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@koopjs/provider-file-geojson": "^2.1.0",
     "await-spawn": "^4.0.2",
-    "@babel/eslint-parser": "^7.11.0",
     "byline": "^5.0.0",
     "commitizen": "^4.2.5",
     "commitlint": "^17.2.0",

--- a/packages/featureserver/coverage-unit.svg
+++ b/packages/featureserver/coverage-unit.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 89.04%">
-  <title>coverage: 89.04%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 88.62%">
+  <title>coverage: 88.62%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">89.04%</text>
-    <text x="648" y="138" textLength="440">89.04%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">88.62%</text>
+    <text x="648" y="138" textLength="440">88.62%</text>
   </g>
   
 </svg>

--- a/packages/featureserver/coverage.svg
+++ b/packages/featureserver/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 95.29%">
-  <title>coverage: 95.29%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.82%">
+  <title>coverage: 94.82%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">95.29%</text>
-    <text x="648" y="138" textLength="440">95.29%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.82%</text>
+    <text x="648" y="138" textLength="440">94.82%</text>
   </g>
   
 </svg>

--- a/packages/featureserver/src/error.js
+++ b/packages/featureserver/src/error.js
@@ -12,6 +12,7 @@ const authorizationErrorResponse = {
     details: [],
   },
 };
+
 const responseHandler = require('./response-handler');
 
 /**

--- a/packages/featureserver/src/geoservice-error.js
+++ b/packages/featureserver/src/geoservice-error.js
@@ -1,0 +1,13 @@
+
+class GeoServiceError extends Error {
+  constructor (code, message, details = []) {
+    super(message);
+    this.code = code;
+
+    this.details = Array.isArray(details) ? details : [details];
+
+    Error.captureStackTrace(this, GeoServiceError);
+  }
+}
+
+module.exports = { GeoServiceError };

--- a/packages/featureserver/src/response-handler.js
+++ b/packages/featureserver/src/response-handler.js
@@ -3,7 +3,14 @@ module.exports = function responseHandler (req, res, statusCode, payload) {
     let sanitizedCallback = req.query.callback.replace(/[^\w\d\.\(\)\[\]]/g, '') // eslint-disable-line
     res.set('Content-Type', 'application/javascript');
     res.status(statusCode);
-    res.send(`${sanitizedCallback}(${JSON.stringify(payload)})`);
-  } else if (req.query && req.query.f === 'pjson') res.set('Content-type', 'application/json; charset=utf-8').status(statusCode).send(JSON.stringify(payload, null, 2));
-  else res.status(statusCode).json(payload);
+    return res.send(`${sanitizedCallback}(${JSON.stringify(payload)})`);
+  }
+  
+  if (req.query?.f === 'pjson') {
+    res.set('Content-type', 'application/json; charset=utf-8');
+    res.status(statusCode);
+    return res.send(JSON.stringify(payload, null, 2));
+  }
+  
+  return res.status(statusCode).json(payload);
 };

--- a/packages/featureserver/src/route.js
+++ b/packages/featureserver/src/route.js
@@ -55,8 +55,11 @@ module.exports = function route(req, res, geojson = {}) {
     return responseHandler(req, res, 200, result);
   } catch (error) {
     logger.debug(error);
-    return responseHandler(req, res, error.code || 500, {
-      error: error.message,
+    const { code = 500 , message, details = [message] } = error;
+    
+    // Geoservice spec wraps all errors in a 200 response (!)
+    return responseHandler(req, res, 200, {
+      error: { code, message, details }
     });
   }
 };

--- a/packages/featureserver/src/route.spec.js
+++ b/packages/featureserver/src/route.spec.js
@@ -1,4 +1,4 @@
-const should = require('should') // eslint-disable-line
+const should = require('should'); // eslint-disable-line
 const sinon = require('sinon');
 require('should-sinon');
 const proxyquire = require('proxyquire');
@@ -7,7 +7,7 @@ describe('Route module unit tests', () => {
   describe('/query route', () => {
     const querySpy = sinon.spy(function () {
       return {
-        features: []
+        features: [],
       };
     });
 
@@ -15,58 +15,77 @@ describe('Route module unit tests', () => {
 
     const route = proxyquire('./route', {
       './query': querySpy,
-      './response-handler': responseHandlerSpy
+      './response-handler': responseHandlerSpy,
     });
 
     it('should use query handler and return 200', () => {
-      route({
-        params: { method: 'query' },
-        query: {},
-        url: '/FeatureServer/0/query'
-      }, {}, {});
+      route(
+        {
+          params: { method: 'query' },
+          query: {},
+          url: '/FeatureServer/0/query',
+        },
+        {},
+        {},
+      );
       querySpy.calledOnce.should.equal(true);
-      querySpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        resultRecordCount: 2000
-      }]);
+      querySpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          resultRecordCount: 2000,
+        },
+      ]);
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: { method: 'query' },
-        query: { resultRecordCount: 2000 },
-        url: '/FeatureServer/0/query'
-      },
-      {},
-      200,
-      { features: [] }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: { method: 'query' },
+          query: { resultRecordCount: 2000 },
+          url: '/FeatureServer/0/query',
+        },
+        {},
+        200,
+        { features: [] },
       ]);
     });
 
     it('should use query handler and handle error', () => {
       const querySpy = sinon.spy(function () {
-        throw new Error('Food bar');
+        throw new Error('Fool bar');
       });
 
       const route = proxyquire('./route', {
         './query': querySpy,
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: { method: 'query' },
-        query: {},
-        url: '/FeatureServer/0/query'
-      }, {}, {});
+      route(
+        {
+          params: { method: 'query' },
+          query: {},
+          url: '/FeatureServer/0/query',
+        },
+        {},
+        {},
+      );
       querySpy.calledOnce.should.equal(true);
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: { method: 'query' },
-        query: { resultRecordCount: 2000 },
-        url: '/FeatureServer/0/query'
-      },
-      {},
-      500,
-      { error: 'Food bar' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: { method: 'query' },
+          query: { resultRecordCount: 2000 },
+          url: '/FeatureServer/0/query',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 500,
+            message: 'Fool bar',
+            details: ['Fool bar'],
+          },
+        },
       ]);
     });
     afterEach(() => {
@@ -84,35 +103,41 @@ describe('Route module unit tests', () => {
 
     const route = proxyquire('./route', {
       './rest-info-route-handler': restInfoSpy,
-      './response-handler': responseHandlerSpy
+      './response-handler': responseHandlerSpy,
     });
 
     it('should use restInfo handler and return 200', () => {
-      route({
-        params: {},
-        query: {},
-        url: '/rest/info'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/info',
+        },
+        {},
+        {},
+      );
       restInfoSpy.calledOnce.should.equal(true);
       restInfoSpy.firstCall.args.should.deepEqual([
         {
-          metadata: { maxRecordCount: 2000 }
-        }, {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
           params: {},
           query: { resultRecordCount: 2000 },
-          url: '/rest/info'
-        }
+          url: '/rest/info',
+        },
       ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/info'
-      },
-      {},
-      200,
-      { restInfo: true }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/info',
+        },
+        {},
+        200,
+        { restInfo: true },
       ]);
     });
 
@@ -122,35 +147,46 @@ describe('Route module unit tests', () => {
       });
       const route = proxyquire('./route', {
         './rest-info-route-handler': restInfoSpy,
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: {},
-        query: {},
-        url: '/rest/info'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/info',
+        },
+        {},
+        {},
+      );
       restInfoSpy.calledOnce.should.equal(true);
       restInfoSpy.firstCall.args.should.deepEqual([
         {
-          metadata: { maxRecordCount: 2000 }
+          metadata: { maxRecordCount: 2000 },
         },
         {
           params: {},
           query: { resultRecordCount: 2000 },
-          url: '/rest/info'
-        }
+          url: '/rest/info',
+        },
       ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/info'
-      },
-      {},
-      500,
-      { error: 'Fool bar' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/info',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 500,
+            message: 'Fool bar',
+            details: ['Fool bar'],
+          },
+        },
       ]);
     });
 
@@ -169,33 +205,41 @@ describe('Route module unit tests', () => {
 
     const route = proxyquire('./route', {
       './server-info-route-handler': serverInfoSpy,
-      './response-handler': responseHandlerSpy
+      './response-handler': responseHandlerSpy,
     });
 
     it('should use serverInfo handler and return 200', () => {
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer',
+        },
+        {},
+        {},
+      );
       serverInfoSpy.calledOnce.should.equal(true);
-      serverInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer'
-      }]);
+      serverInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer',
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer'
-      },
-      {},
-      200,
-      { serverInfo: true }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer',
+        },
+        {},
+        200,
+        { serverInfo: true },
       ]);
     });
 
@@ -205,32 +249,46 @@ describe('Route module unit tests', () => {
       });
       const route = proxyquire('./route', {
         './server-info-route-handler': serverInfoSpy,
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer',
+        },
+        {},
+        {},
+      );
       serverInfoSpy.calledOnce.should.equal(true);
-      serverInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer'
-      }]);
+      serverInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer',
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer'
-      },
-      {},
-      500,
-      { error: 'Fool bar' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 500,
+            message: 'Fool bar',
+            details: ['Fool bar'],
+          },
+        },
       ]);
     });
 
@@ -249,31 +307,39 @@ describe('Route module unit tests', () => {
 
     const route = proxyquire('./route', {
       './layers-metadata': layersInfoSpy,
-      './response-handler': responseHandlerSpy
+      './response-handler': responseHandlerSpy,
     });
 
     it('should use layersInfo handler and return 200', () => {
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer/layers'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer/layers',
+        },
+        {},
+        {},
+      );
       layersInfoSpy.calledOnce.should.equal(true);
-      layersInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        resultRecordCount: 2000
-      }]);
+      layersInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          resultRecordCount: 2000,
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/layers'
-      },
-      {},
-      200,
-      { layersInfo: true }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/layers',
+        },
+        {},
+        200,
+        { layersInfo: true },
       ]);
     });
 
@@ -283,30 +349,44 @@ describe('Route module unit tests', () => {
       });
       const route = proxyquire('./route', {
         './layers-metadata': layersInfoSpy,
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer/layers'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer/layers',
+        },
+        {},
+        {},
+      );
       layersInfoSpy.calledOnce.should.equal(true);
-      layersInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        resultRecordCount: 2000
-      }]);
+      layersInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          resultRecordCount: 2000,
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/layers'
-      },
-      {},
-      500,
-      { error: 'Fool bar' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/layers',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 500,
+            message: 'Fool bar',
+            details: ['Fool bar'],
+          },
+        },
       ]);
     });
 
@@ -325,33 +405,41 @@ describe('Route module unit tests', () => {
 
     const route = proxyquire('./route', {
       './layer-metadata': layerInfoSpy,
-      './response-handler': responseHandlerSpy
+      './response-handler': responseHandlerSpy,
     });
 
     it('should use layerInfo handler and return 200', () => {
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer/0'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer/0',
+        },
+        {},
+        {},
+      );
       layerInfoSpy.calledOnce.should.equal(true);
-      layerInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/0'
-      }]);
+      layerInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/0',
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/0'
-      },
-      {},
-      200,
-      'layer-metadata'
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/0',
+        },
+        {},
+        200,
+        'layer-metadata',
       ]);
     });
 
@@ -361,32 +449,46 @@ describe('Route module unit tests', () => {
       });
       const route = proxyquire('./route', {
         './layer-metadata': layerInfoSpy,
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: {},
-        query: {},
-        url: '/rest/services/test/FeatureServer/0'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/rest/services/test/FeatureServer/0',
+        },
+        {},
+        {},
+      );
       layerInfoSpy.calledOnce.should.equal(true);
-      layerInfoSpy.firstCall.args.should.deepEqual([{
-        metadata: { maxRecordCount: 2000 }
-      }, {
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/0'
-      }]);
+      layerInfoSpy.firstCall.args.should.deepEqual([
+        {
+          metadata: { maxRecordCount: 2000 },
+        },
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/0',
+        },
+      ]);
 
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/rest/services/test/FeatureServer/0'
-      },
-      {},
-      500,
-      { error: 'Fool bar' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/rest/services/test/FeatureServer/0',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 500,
+            message: 'Fool bar',
+            details: ['Fool bar'],
+          },
+        },
       ]);
     });
 
@@ -400,23 +502,34 @@ describe('Route module unit tests', () => {
     it('should handle unknown route', () => {
       const responseHandlerSpy = sinon.spy();
       const route = proxyquire('./route', {
-        './response-handler': responseHandlerSpy
+        './response-handler': responseHandlerSpy,
       });
 
-      route({
-        params: {},
-        query: {},
-        url: '/hello/world'
-      }, {}, {});
+      route(
+        {
+          params: {},
+          query: {},
+          url: '/hello/world',
+        },
+        {},
+        {},
+      );
       responseHandlerSpy.calledOnce.should.equal(true);
-      responseHandlerSpy.firstCall.args.should.deepEqual([{
-        params: {},
-        query: { resultRecordCount: 2000 },
-        url: '/hello/world'
-      },
-      {},
-      404,
-      { error: 'Not Found' }
+      responseHandlerSpy.firstCall.args.should.deepEqual([
+        {
+          params: {},
+          query: { resultRecordCount: 2000 },
+          url: '/hello/world',
+        },
+        {},
+        200,
+        {
+          error: {
+            code: 404,
+            message: 'Not Found',
+            details: ['Not Found'],
+          },
+        },
       ]);
     });
   });

--- a/packages/featureserver/test/integration/route.spec.js
+++ b/packages/featureserver/test/integration/route.spec.js
@@ -164,10 +164,16 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/foobarbaz')
         .expect(res => {
-          res.body.error.should.equal('Method not supported');
+          res.body.should.deepEqual({
+            error: {
+              code: 400,
+              message: 'Method not supported',
+              details: ['Method not supported']
+            }
+          });
         })
         .expect('Content-Type', /json/)
-        .expect(400, done);
+        .expect(200, done);
     });
   });
 

--- a/packages/koop-core/coverage.svg
+++ b/packages/koop-core/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.55%">
-  <title>coverage: 92.55%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.19%">
+  <title>coverage: 92.19%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.55%</text>
-    <text x="648" y="138" textLength="440">92.55%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.19%</text>
+    <text x="648" y="138" textLength="440">92.19%</text>
   </g>
   
 </svg>


### PR DESCRIPTION
The PR wraps FeatureServer response errors according to the ArcGIS specification and gives them a 200 status.  Weird, I know, but that's what ArcGIS client's expect.