### PR TITLE
fix: hash feature before date transformation

### DIFF
--- a/.changeset/honest-cats-own.md
+++ b/.changeset/honest-cats-own.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/winnow': patch
+---
+
+- transform ISO dates to epoch time after hashing

--- a/.changeset/plenty-cobras-repair.md
+++ b/.changeset/plenty-cobras-repair.md
@@ -1,5 +1,0 @@
----
-'@koopjs/koop-core': patch
----
-
-- use new \_cache metadata property when available

--- a/.changeset/plenty-lamps-jam.md
+++ b/.changeset/plenty-lamps-jam.md
@@ -1,5 +1,0 @@
----
-'@koopjs/cache-memory': patch
----
-
-- update cache expire time when updating the cache

--- a/.changeset/plenty-lamps-jam.md
+++ b/.changeset/plenty-lamps-jam.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/cache-memory': patch
+---
+
+- update cache expire time when updating the cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,20 +1642,6 @@
         "node": ">=v14"
       }
     },
-    "node_modules/@commitlint/read/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "17.4.4",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
@@ -2931,6 +2917,21 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@lerna/create/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@lerna/create/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3153,6 +3154,21 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@lerna/legacy-package-management/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@lerna/legacy-package-management/node_modules/get-stream": {
@@ -7942,6 +7958,21 @@
         "node": ">= 12"
       }
     },
+    "node_modules/commitizen/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/commitlint": {
       "version": "17.6.1",
       "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-17.6.1.tgz",
@@ -8346,20 +8377,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/coverage-badges-cli/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/crc-32": {
@@ -10221,18 +10238,17 @@
       "devOptional": true
     },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dev": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
@@ -14304,6 +14320,21 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/lerna/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lerna/node_modules/get-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
@@ -17472,20 +17503,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nx/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/nx/node_modules/glob": {
@@ -23108,20 +23125,6 @@
       "optionalDependencies": {
         "farmhash": "^3.1.0"
       }
-    },
-    "packages/winnow/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
     }
   },
   "dependencies": {
@@ -24405,19 +24408,6 @@
         "fs-extra": "^11.0.0",
         "git-raw-commits": "^2.0.11",
         "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -25394,19 +25384,6 @@
         "tap-spec": "^5.0.0",
         "tape": "^5.0.0",
         "wkt-parser": "^1.2.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@lerna/child-process": {
@@ -25492,6 +25469,18 @@
         "yargs-parser": "20.2.4"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -25668,6 +25657,18 @@
             "onetime": "^5.1.2",
             "signal-exit": "^3.0.3",
             "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
@@ -29375,6 +29376,20 @@
         "minimist": "1.2.7",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "commitlint": {
@@ -29698,19 +29713,6 @@
         "fs-extra": "~11.1.0",
         "mini-svg-data-uri": "^1.4.4",
         "minimist": "~1.2.5"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "crc-32": {
@@ -31135,12 +31137,11 @@
       "devOptional": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -34105,6 +34106,18 @@
             "strip-final-newline": "^2.0.0"
           }
         },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "get-stream": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
@@ -36597,17 +36610,6 @@
             "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
             "micromatch": "^4.0.4"
-          }
-        },
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         },
         "glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,13 +1278,13 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.5.1.tgz",
-      "integrity": "sha512-pRRgGSzdHQHehxZbGA3qF6wVPyl+EEQgTe/t321rtMLFbuJ7nRj2waS17s/v5oEbyZtiY5S8PGB6XtEIm0I+Sg==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.1.tgz",
+      "integrity": "sha512-kCnDD9LE2ySiTnj/VPaxy4/oRayRcdv4aCuVxtoum8SxIU7OADHc0nJPQfheE8bHcs3zZdWzDMWltRosuT13bg==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.4.4",
+        "@commitlint/lint": "^17.6.1",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
-      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.6.1.tgz",
+      "integrity": "sha512-ng/ybaSLuTCH9F+7uavSOnEQ9EFMl7lHEjfAEgRh1hwmEe8SpLKpQeMo2aT1IWvHaGMuTb+gjfbzoRf2IR23NQ==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -1476,14 +1476,14 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
-      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.1.tgz",
+      "integrity": "sha512-VARJ9kxH64isgwVnC+ABPafCYzqxpsWJIpDaTuI0gh8aX4GQ0i7cn9tvxtFNfJj4ER2BAJeWJ0vURdNYjK2RQQ==",
       "dev": true,
       "dependencies": {
         "@commitlint/is-ignored": "^17.4.4",
         "@commitlint/parse": "^17.4.4",
-        "@commitlint/rules": "^17.4.4",
+        "@commitlint/rules": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       },
       "engines": {
@@ -1674,9 +1674,9 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
-      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
+      "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
       "dev": true,
       "dependencies": {
         "@commitlint/ensure": "^17.4.4",
@@ -7943,12 +7943,12 @@
       }
     },
     "node_modules/commitlint": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-17.5.1.tgz",
-      "integrity": "sha512-BmYX5GJrZFk/90Owlsoh7J38hbikK1AIE+j0MlU0U+Vns+JNHwOE+6jkU9UYEiyY9rrgrI50kx2thI3028FwGw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-17.6.1.tgz",
+      "integrity": "sha512-yO11o5DmN/X4VCL+aLzgfJ1YXOM7qFzMN659SpISS4EBiv+QO16A0jeJU9rgVRbM2K06M7AfBQkZz7EPR3sAnQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/cli": "^17.5.1",
+        "@commitlint/cli": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       },
       "bin": {
@@ -24133,13 +24133,13 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@commitlint/cli": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.5.1.tgz",
-      "integrity": "sha512-pRRgGSzdHQHehxZbGA3qF6wVPyl+EEQgTe/t321rtMLFbuJ7nRj2waS17s/v5oEbyZtiY5S8PGB6XtEIm0I+Sg==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.1.tgz",
+      "integrity": "sha512-kCnDD9LE2ySiTnj/VPaxy4/oRayRcdv4aCuVxtoum8SxIU7OADHc0nJPQfheE8bHcs3zZdWzDMWltRosuT13bg==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.4.4",
+        "@commitlint/lint": "^17.6.1",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -24151,9 +24151,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
-      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.6.1.tgz",
+      "integrity": "sha512-ng/ybaSLuTCH9F+7uavSOnEQ9EFMl7lHEjfAEgRh1hwmEe8SpLKpQeMo2aT1IWvHaGMuTb+gjfbzoRf2IR23NQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -24281,14 +24281,14 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
-      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.1.tgz",
+      "integrity": "sha512-VARJ9kxH64isgwVnC+ABPafCYzqxpsWJIpDaTuI0gh8aX4GQ0i7cn9tvxtFNfJj4ER2BAJeWJ0vURdNYjK2RQQ==",
       "dev": true,
       "requires": {
         "@commitlint/is-ignored": "^17.4.4",
         "@commitlint/parse": "^17.4.4",
-        "@commitlint/rules": "^17.4.4",
+        "@commitlint/rules": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       }
     },
@@ -24435,9 +24435,9 @@
       }
     },
     "@commitlint/rules": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
-      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
+      "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
       "dev": true,
       "requires": {
         "@commitlint/ensure": "^17.4.4",
@@ -29378,12 +29378,12 @@
       }
     },
     "commitlint": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-17.5.1.tgz",
-      "integrity": "sha512-BmYX5GJrZFk/90Owlsoh7J38hbikK1AIE+j0MlU0U+Vns+JNHwOE+6jkU9UYEiyY9rrgrI50kx2thI3028FwGw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/commitlint/-/commitlint-17.6.1.tgz",
+      "integrity": "sha512-yO11o5DmN/X4VCL+aLzgfJ1YXOM7qFzMN659SpISS4EBiv+QO16A0jeJU9rgVRbM2K06M7AfBQkZz7EPR3sAnQ==",
       "dev": true,
       "requires": {
-        "@commitlint/cli": "^17.5.1",
+        "@commitlint/cli": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9747,23 +9747,23 @@
       }
     },
     "node_modules/farmhash": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.2.2.tgz",
-      "integrity": "sha512-vhGKzOrdw2VgB8uqHtCQhQxgP2N0UwKCQo8m0cdD9KzyFJs8wbvFS5UzUJw1aHRCxciBgEVxF4ilF7jZ/6US3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.3.0.tgz",
+      "integrity": "sha512-IZJWJXvX+TZJ4qZrcRZkDqI66s4VxrRD+NsduTSe0PZ9BGEDB53S0cd+e4rTXIWbL5k213W8cN6pMZuPVA+z0Q==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0"
+        "node-addon-api": "^5.1.0",
+        "prebuild-install": "^7.1.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/farmhash/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "optional": true
     },
     "node_modules/fast-deep-equal": {
@@ -30770,19 +30770,19 @@
       }
     },
     "farmhash": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.2.2.tgz",
-      "integrity": "sha512-vhGKzOrdw2VgB8uqHtCQhQxgP2N0UwKCQo8m0cdD9KzyFJs8wbvFS5UzUJw1aHRCxciBgEVxF4ilF7jZ/6US3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.3.0.tgz",
+      "integrity": "sha512-IZJWJXvX+TZJ4qZrcRZkDqI66s4VxrRD+NsduTSe0PZ9BGEDB53S0cd+e4rTXIWbL5k213W8cN6pMZuPVA+z0Q==",
       "optional": true,
       "requires": {
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0"
+        "node-addon-api": "^5.1.0",
+        "prebuild-install": "^7.1.1"
       },
       "dependencies": {
         "node-addon-api": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+          "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22953,7 +22953,7 @@
     },
     "packages/cache-memory": {
       "name": "@koopjs/cache-memory",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.4"
@@ -23005,10 +23005,10 @@
     },
     "packages/koop-core": {
       "name": "@koopjs/koop-core",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@koopjs/cache-memory": "4.0.0",
+        "@koopjs/cache-memory": "4.0.1",
         "@koopjs/logger": "5.0.0",
         "@koopjs/output-geoservices": "6.0.2",
         "body-parser": "^1.19.0",
@@ -25323,7 +25323,7 @@
     "@koopjs/koop-core": {
       "version": "file:packages/koop-core",
       "requires": {
-        "@koopjs/cache-memory": "4.0.0",
+        "@koopjs/cache-memory": "4.0.1",
         "@koopjs/logger": "5.0.0",
         "@koopjs/output-geoservices": "6.0.2",
         "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23005,7 +23005,7 @@
     },
     "packages/koop-core": {
       "name": "@koopjs/koop-core",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@koopjs/cache-memory": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13730,9 +13730,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.8.4",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.4.tgz",
-      "integrity": "sha512-jjdRHb5WtL+KgSHvOULQEPPv4kcl+ixd1ybOFQq3rWLgEEqc03QMmilodL0GVJE14U/SQDXkUhQUSZANGDH/AA==",
+      "version": "17.9.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.1.tgz",
+      "integrity": "sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -33725,9 +33725,9 @@
       }
     },
     "joi": {
-      "version": "17.8.4",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.4.tgz",
-      "integrity": "sha512-jjdRHb5WtL+KgSHvOULQEPPv4kcl+ixd1ybOFQq3rWLgEEqc03QMmilodL0GVJE14U/SQDXkUhQUSZANGDH/AA==",
+      "version": "17.9.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.1.tgz",
+      "integrity": "sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",

--- a/packages/cache-memory/CHANGELOG.md
+++ b/packages/cache-memory/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @koopjs/cache-memory
 
+## 4.0.1
+
+### Patch Changes
+
+- update cache expire time when updating the cache
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/cache-memory/coverage.svg
+++ b/packages/cache-memory/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 96.29%">
-  <title>coverage: 96.29%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 96.38%">
+  <title>coverage: 96.38%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">96.29%</text>
-    <text x="648" y="138" textLength="440">96.29%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">96.38%</text>
+    <text x="648" y="138" textLength="440">96.38%</text>
   </g>
   
 </svg>

--- a/packages/cache-memory/package.json
+++ b/packages/cache-memory/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@koopjs/cache-memory",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "An in-memory cache for KOop",
   "main": "src/index.js",
   "scripts": {
     "test": "tape src/**/*.spec.js | tap-spec",
     "test:cov": "nyc -r=json-summary tape './src/**/*.spec.js' | tap-spec && npm run cov:badge",
     "cov:badge": "coverage-badges-cli --output ./coverage.svg"
-    },
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/koopjs/koop.git"

--- a/packages/koop-core/CHANGELOG.md
+++ b/packages/koop-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @koopjs/koop-core
 
+## 8.0.4
+
+### Patch Changes
+
+- Updated dependencies [1e8df8d]
+  - @koopjs/cache-memory@4.0.1
+
 ## 8.0.3
 
 ### Patch Changes

--- a/packages/koop-core/CHANGELOG.md
+++ b/packages/koop-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @koopjs/koop-core
 
+## 8.0.3
+
+### Patch Changes
+
+- use new \_cache metadata property when available
+
 ## 8.0.2
 
 ### Patch Changes

--- a/packages/koop-core/package-lock.json
+++ b/packages/koop-core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@koopjs/cache-memory": "4.0.0",
+        "@koopjs/cache-memory": "4.0.1",
         "@koopjs/logger": "5.0.0",
         "@koopjs/output-geoservices": "6.0.2",
         "body-parser": "^1.19.0",
@@ -64,14 +64,6 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@koopjs/cache-memory": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@koopjs/cache-memory/-/cache-memory-4.0.0.tgz",
-      "integrity": "sha512-xsKWQHb93rotGde9FIaNKVYwDrsSyXu4jMHsnH6WTvjZ00K9GqR8Wz9dVKcnJJhcMUHtooGNBia3x9bYYhd6cw==",
-      "dependencies": {
-        "lodash": "^4.17.4"
       }
     },
     "node_modules/@koopjs/featureserver": {

--- a/packages/koop-core/package-lock.json
+++ b/packages/koop-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koopjs/koop-core",
-  "version": "8.0.2",
+  "version": "8.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koopjs/koop-core",
-      "version": "8.0.2",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@koopjs/cache-memory": "4.0.1",
@@ -64,6 +64,14 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@koopjs/cache-memory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@koopjs/cache-memory/-/cache-memory-4.0.1.tgz",
+      "integrity": "sha512-U/LQt3Rbw7/4ttCHZl6UJGzz3XRo1EDA7iZVN3mYZEFwzLF7BW88Y6A1WtYpYglB8zZ2GZK1NoUrWdQWS1Yo8g==",
+      "dependencies": {
+        "lodash": "^4.17.4"
       }
     },
     "node_modules/@koopjs/featureserver": {
@@ -3348,9 +3356,9 @@
       }
     },
     "@koopjs/cache-memory": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@koopjs/cache-memory/-/cache-memory-4.0.0.tgz",
-      "integrity": "sha512-xsKWQHb93rotGde9FIaNKVYwDrsSyXu4jMHsnH6WTvjZ00K9GqR8Wz9dVKcnJJhcMUHtooGNBia3x9bYYhd6cw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@koopjs/cache-memory/-/cache-memory-4.0.1.tgz",
+      "integrity": "sha512-U/LQt3Rbw7/4ttCHZl6UJGzz3XRo1EDA7iZVN3mYZEFwzLF7BW88Y6A1WtYpYglB8zZ2GZK1NoUrWdQWS1Yo8g==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/packages/koop-core/package.json
+++ b/packages/koop-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@koopjs/koop-core",
   "description": "Serve, transform, and query geospatial data on the web",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "contributors": [
     {
       "name": "Rich Gwozdz",
@@ -68,5 +68,5 @@
     "test": "mocha '**/*.spec.js' ",
     "test:cov": "nyc -r=json-summary mocha '**/*.spec.js' && npm run cov:badge",
     "cov:badge": "coverage-badges-cli --output ./coverage.svg"
-    }
+  }
 }

--- a/packages/koop-core/package.json
+++ b/packages/koop-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@koopjs/koop-core",
   "description": "Serve, transform, and query geospatial data on the web",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "contributors": [
     {
       "name": "Rich Gwozdz",
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": {
-    "@koopjs/cache-memory": "4.0.0",
+    "@koopjs/cache-memory": "4.0.1",
     "@koopjs/logger": "5.0.0",
     "@koopjs/output-geoservices": "6.0.2",
     "body-parser": "^1.19.0",

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
@@ -1,13 +1,7 @@
 const test = require('tape');
 const proxyquire = require('proxyquire');
 const modulePath = './to-esri-attributes';
-const toEsriAttributes = proxyquire(modulePath, {
-  '../helpers': {
-    createIntegerHash: () => {
-      return 99999;
-    }
-  }
-});
+const toEsriAttributes = require(modulePath);
 
 test('toEsriAttributes, does not require idField', t => {
   // (properties, geometry, dateFields, requiresObjectId, idField)
@@ -23,7 +17,32 @@ test('toEsriAttributes, requires idField and properties contain it', t => {
   t.end();
 });
 
+test('toEsriAttributes, requires idField, properties contain it, but logs debug message', t => {
+  const toEsriAttributes = proxyquire(modulePath, {
+    '../../logger': {
+      logger: {
+        debug: (message) => {
+          t.equals(message, 'OBJECTIDs created from provider\'s "idField" (OBJECTID: 11111) are not integers from 0 to 2147483647');
+        }
+      }
+    }
+  });
+  // (properties, geometry, dateFields, requiresObjectId, idField)
+  const result = toEsriAttributes({ foo: 'bar', OBJECTID: '11111' }, { coordinates: [-118, 34] }, '', 'true', 'OBJECTID');
+  t.deepEquals(result, { foo: 'bar', OBJECTID: '11111' });
+  t.end();
+});
+
 test('toEsriAttributes, requires idField and properties do not have one, so create hash', t => {
+  const toEsriAttributes = proxyquire(modulePath, {
+    '../helpers': {
+      createIntegerHash: (string) => {
+        t.deepEquals(string, '{"properties":{"foo":"bar"},"geometry":{"coordinates":[-118,34]}}');
+        return 99999;
+      }
+    }
+  });
+  
   // (properties, geometry, dateFields, requiresObjectId, idField)
   const result = toEsriAttributes({ foo: 'bar' }, { coordinates: [-118, 34] }, '', 'true', 'null');
   t.deepEquals(result, { foo: 'bar', OBJECTID: 99999 });
@@ -36,6 +55,33 @@ test('toEsriAttributes, does not require idField, has dateFields', t => {
   const date2 = new Date(1000);
   const result = toEsriAttributes({ hello: 'world', foo: date1.toISOString(), bar: date2.toISOString() }, { coordinates: [-118, 34] }, 'foo,bar', 'false', '');
   t.deepEquals(result, { hello: 'world', foo: date1.getTime(), bar: date2.getTime() });
+  t.end();
+});
+
+test('toEsriAttributes, require idField, has dateFields', t => {
+  const date1 = new Date();
+  const date2 = new Date(1000);
+  
+  const toEsriAttributes = proxyquire(modulePath, {
+    '../helpers': {
+      createIntegerHash: (string) => {
+        t.deepEquals(string, `{"properties":{"hello":"world","foo":"${date1.toISOString()}","bar":"${date2.toISOString()}"},"geometry":{"coordinates":[-118,34]}}`);
+        return 99999;
+      }
+    }
+  });
+  
+  // (properties, geometry, dateFields, requiresObjectId, idField)
+  const result = toEsriAttributes({ hello: 'world', foo: date1.toISOString(), bar: date2.toISOString() }, { coordinates: [-118, 34] }, 'foo,bar', 'true', 'null');
+  t.deepEquals(result, { OBJECTID: 99999, hello: 'world', foo: date1.getTime(), bar: date2.getTime() });
+  t.end();
+});
+
+test('toEsriAttributes, does not require idField, has null dateField', t => {
+  // (properties, geometry, dateFields, requiresObjectId, idField)
+  const date2 = new Date(1000);
+  const result = toEsriAttributes({ hello: 'world', foo: null, bar: date2.toISOString() }, { coordinates: [-118, 34] }, 'foo,bar', 'false', '');
+  t.deepEquals(result, { hello: 'world', foo: null, bar: date2.getTime() });
   t.end();
 });
 

--- a/packages/winnow/test/integration/filter.spec.js
+++ b/packages/winnow/test/integration/filter.spec.js
@@ -2,37 +2,39 @@ const _ = require('lodash');
 const test = require('tape');
 const winnow = require('../..');
 
-test('With a where option', t => {
+test('With a where option', (t) => {
   const options = {
-    where: 'Genus like \'%Quercus%\''
+    where: 'Genus like \'%Quercus%\'',
   };
   run('trees', options, 8, t);
 });
 
-test('With a where options 1=1', t => {
+test('With a where options 1=1', (t) => {
   const options = {
-    where: '1=1'
+    where: '1=1',
   };
   run('trees', options, 24, t);
 });
 
-test('With a where option with multiple statements', t => {
+test('With a where option with multiple statements', (t) => {
   const options = {
-    where: 'Genus like \'%Quercus%\' AND Street_Name = \'CLAREMONT\' AND House_Number < 600 AND Trunk_Diameter = 9'
+    where:
+      'Genus like \'%Quercus%\' AND Street_Name = \'CLAREMONT\' AND House_Number < 600 AND Trunk_Diameter = 9',
   };
   run('trees', options, 1, t);
 });
 
-test('With a where option with multiple statements with appended 1=1', t => {
+test('With a where option with multiple statements with appended 1=1', (t) => {
   const options = {
-    where: 'Genus like \'%Quercus%\' AND Street_Name = \'CLAREMONT\' AND House_Number < 600 AND Trunk_Diameter = 9 AND 1=1'
+    where:
+      'Genus like \'%Quercus%\' AND Street_Name = \'CLAREMONT\' AND House_Number < 600 AND Trunk_Diameter = 9 AND 1=1',
   };
   run('trees', options, 1, t);
 });
 
-test('With a field that has been uppercased', t => {
+test('With a field that has been uppercased', (t) => {
   const options = {
-    where: 'UPPER(Genus) like \'%Quercus%\''
+    where: 'UPPER(Genus) like \'%Quercus%\'',
   };
   t.plan(1);
   const fixtures = _.cloneDeep(require('./fixtures/trees.json'));
@@ -41,24 +43,24 @@ test('With a field that has been uppercased', t => {
   t.equal(filtered.length, 8);
 });
 
-test('With the toEsri option', t => {
+test('With the toEsri option', (t) => {
   const options = {
     toEsri: true,
-    where: 'Genus like \'%Quercus%\''
+    where: 'Genus like \'%Quercus%\'',
   };
   run('trees', options, 8, t);
 });
 
-test('With the toEsri option and a null geometry', t => {
+test('With the toEsri option and a null geometry', (t) => {
   const options = {
-    toEsri: true
+    toEsri: true,
   };
   run('nogeom', options, 18, t);
 });
 
-test('With a field with a space', t => {
+test('With a field with a space', (t) => {
   const options = {
-    where: '"total precip" > 0.5'
+    where: '"total precip" > 0.5',
   };
   t.plan(1);
   const fixtures = _.cloneDeep(require('./fixtures/snow.json'));
@@ -67,78 +69,80 @@ test('With a field with a space', t => {
   t.equal(filtered.length, 3);
 });
 
-test('With esri json', t => {
+test('With esri json', (t) => {
   const options = {
     where: 'Genus like \'%Quercus%\'',
-    esri: true
+    esri: true,
   };
   run('esri', options, 8, t);
 });
 
-test('With multiple like clauses', t => {
+test('With multiple like clauses', (t) => {
   const options = {
-    where: 'Genus like \'%Quercus%\' AND Common_Name like \'%Live Oak%\' AND Street_Type like \'%ST%\''
+    where:
+      'Genus like \'%Quercus%\' AND Common_Name like \'%Live Oak%\' AND Street_Type like \'%ST%\'',
   };
   run('trees', options, 5, t);
 });
 
-test('With an in parameter', t => {
+test('With an in parameter', (t) => {
   const options = {
-    where: 'Genus IN (\'QUERCUS\', \'EUGENIA\')'
+    where: 'Genus IN (\'QUERCUS\', \'EUGENIA\')',
   };
   run('trees', options, 8, t);
 });
 
-test('With an is parameter', t => {
+test('With an is parameter', (t) => {
   const options = {
-    where: 'Species IS NULL'
+    where: 'Species IS NULL',
   };
   run('trees', options, 1, t);
 });
 
-test('With two is and one and parameters', t => {
+test('With two is and one and parameters', (t) => {
   const options = {
-    where: 'Species IS NULL AND Street_Direction IS NOT NULL'
+    where: 'Species IS NULL AND Street_Direction IS NOT NULL',
   };
   run('trees', options, 1, t);
 });
 
-test('With an > parameter', t => {
+test('With an > parameter', (t) => {
   const options = {
-    where: 'Trunk_Diameter>10'
+    where: 'Trunk_Diameter>10',
   };
   run('trees', options, 12, t);
 });
 
-test('With an >= parameter', t => {
+test('With an >= parameter', (t) => {
   const options = {
-    where: 'Trunk_Diameter>=10'
+    where: 'Trunk_Diameter>=10',
   };
   run('trees', options, 12, t);
 });
 
-test('With an IN parameter and a numeric test', t => {
+test('With an IN parameter and a numeric test', (t) => {
   const options = {
-    where: 'Genus IN (\'QUERCUS\', \'JACARANDA\') AND Trunk_Diameter>=13'
+    where: 'Genus IN (\'QUERCUS\', \'JACARANDA\') AND Trunk_Diameter>=13',
   };
   run('trees', options, 6, t);
 });
 
-test('With an AND and an OR', t => {
+test('With an AND and an OR', (t) => {
   const options = {
-    where: '(Genus like \'%Quercus%\' AND Common_Name like \'%Live Oak%\') OR Street_Type like \'%AVE%\''
+    where:
+      '(Genus like \'%Quercus%\' AND Common_Name like \'%Live Oak%\') OR Street_Type like \'%AVE%\'',
   };
   run('trees', options, 13, t);
 });
 
-test('With an equality parameter', t => {
+test('With an equality parameter', (t) => {
   const options = {
-    where: 'Common_Name = \'LIVE OAK\''
+    where: 'Common_Name = \'LIVE OAK\'',
   };
   run('trees', options, 6, t);
 });
 
-test('With an esri style envelope', t => {
+test('With an esri style envelope', (t) => {
   const options = {
     geometry: {
       xmin: -13151597,
@@ -146,9 +150,9 @@ test('With an esri style envelope', t => {
       xmax: -13150342,
       ymax: 4051582,
       spatialReference: {
-        wkid: 102100
-      }
-    }
+        wkid: 102100,
+      },
+    },
   };
   const fixtures = _.cloneDeep(require('./fixtures/trees.json'));
   const features = fixtures.features;
@@ -157,7 +161,7 @@ test('With an esri style envelope', t => {
   t.end();
 });
 
-test('With an esri style envelope and features with missing geometry', t => {
+test('With an esri style envelope and features with missing geometry', (t) => {
   const options = {
     outSr: 4326,
     inSr: 4326,
@@ -167,15 +171,15 @@ test('With an esri style envelope and features with missing geometry', t => {
       xmax: 90,
       ymax: 85,
       spatialReference: {
-        wkid: 4326
-      }
+        wkid: 4326,
+      },
     },
-    esri: true
+    esri: true,
   };
   run('missing-geometry', options, 2, t);
 });
 
-test('With an esri style envelope and wkt string for web mercator', t => {
+test('With an esri style envelope and wkt string for web mercator', (t) => {
   const options = {
     geometry: {
       xmin: -13151597,
@@ -183,15 +187,14 @@ test('With an esri style envelope and wkt string for web mercator', t => {
       xmax: -13150342,
       ymax: 4051582,
       spatialReference: {
-        wkt:
-          'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-97.03124999997486],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
-      }
-    }
+        wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-97.03124999997486],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]',
+      },
+    },
   };
   run('trees', options, 6, t);
 });
 
-test('With an empty multipolygon', t => {
+test('With an empty multipolygon', (t) => {
   const options = {
     geometry: {
       xmin: -8968940.494006854,
@@ -199,26 +202,26 @@ test('With an empty multipolygon', t => {
       xmax: -8944480.644955631,
       ymax: 2949342.3497730596,
       spatialReference: {
-        wkid: 102100
-      }
-    }
+        wkid: 102100,
+      },
+    },
   };
   run('emptyMultiPolygon', options, 1, t);
 });
 
-test('Without a spatialReference property on an Esri-style Envelope', t => {
+test('Without a spatialReference property on an Esri-style Envelope', (t) => {
   const options = {
     geometry: {
       xmin: -118.1406,
       ymin: 34.1635,
       xmax: -118.1348,
-      ymax: 34.1685
-    }
+      ymax: 34.1685,
+    },
   };
   run('trees', options, 6, t);
 });
 
-test('With an esri style envelope with xmin = 0, ans esri features', t => {
+test('With an esri style envelope with xmin = 0, ans esri features', (t) => {
   const options = {
     outSr: 4326,
     inSr: 4326,
@@ -228,15 +231,15 @@ test('With an esri style envelope with xmin = 0, ans esri features', t => {
       xmax: 90,
       ymax: 85,
       spatialReference: {
-        wkid: 4326
-      }
+        wkid: 4326,
+      },
     },
-    esri: true
+    esri: true,
   };
   run('startups', options, 2, t);
 });
 
-test('With an esri style envelope in EPSG:102645 defined by wkt', t => {
+test('With an esri style envelope in EPSG:102645 defined by wkt', (t) => {
   const options = {
     geometry: {
       xmin: 6518475,
@@ -258,15 +261,15 @@ test('With an esri style envelope in EPSG:102645 defined by wkt', t => {
         PARAMETER["Standard_Parallel_2",35.46666666666667],
         PARAMETER["Latitude_Of_Origin",33.5],
         UNIT["Foot_US",0.30480060960121924],
-        AUTHORITY["EPSG","102645"]]`
-      }
+        AUTHORITY["EPSG","102645"]]`,
+      },
     },
-    esri: true
+    esri: true,
   };
   run('trees', options, 6, t);
 });
 
-test('With a an Esri-style Polygon', t => {
+test('With a an Esri-style Polygon', (t) => {
   const options = {
     geometry: {
       rings: [
@@ -275,104 +278,145 @@ test('With a an Esri-style Polygon', t => {
           [-118.108, 34.162],
           [-118.108, 34.173],
           [-118.163, 34.173],
-          [-118.163, 34.162]
-        ]
-      ]
+          [-118.163, 34.162],
+        ],
+      ],
     },
-    inSR: 4326
+    inSR: 4326,
   };
   run('trees', options, 12, t);
 });
 
-test('With an array-style geometry', t => {
+test('With an array-style geometry', (t) => {
   const options = {
-    geometry: [-118.1406, 34.1635, -118.1348, 34.1685]
+    geometry: [-118.1406, 34.1635, -118.1348, 34.1685],
   };
   run('trees', options, 6, t);
 });
 
-test('With a string-style geometry', t => {
+test('With a string-style geometry', (t) => {
   const options = {
-    geometry: '-118.1406, 34.1635, -118.1348, 34.1685'
+    geometry: '-118.1406, 34.1635, -118.1348, 34.1685',
   };
   run('trees', options, 6, t);
 });
 
-test('With a point geometry filter', t => {
+test('With a point geometry filter', (t) => {
   const options = {
-    geometry: '-118.16230746759626,34.137113646321595'
+    geometry: '-118.16230746759626,34.137113646321595',
   };
   run('trees', options, 1, t);
 });
 
-test('With a ST_Contains geometry predicate', t => {
-  const options = {
-    geometry: {
-      type: 'Polygon',
-      coordinates: [[[-118.163, 34.162], [-118.108, 34.162], [-118.108, 34.173], [-118.163, 34.173], [-118.163, 34.162]]]
-    },
-    spatialPredicate: 'ST_Contains'
-  };
-  run('trees', options, 12, t);
-});
-
-test('With a ST_Within geometry predicate', t => {
-  const options = {
-    geometry: {
-      type: 'Polygon',
-      coordinates: [[[-118.163, 34.162], [-118.108, 34.162], [-118.108, 34.173], [-118.163, 34.173], [-118.163, 34.162]]]
-    },
-    spatialPredicate: 'ST_Within'
-  };
-  run('trees', options, 12, t);
-});
-
-test('With a ST_EnvelopeIntersects geometry predicate', t => {
+test('With a ST_Contains geometry predicate', (t) => {
   const options = {
     geometry: {
       type: 'Polygon',
       coordinates: [
-        [[-128, 29], [-108, 29], [-108, 50], [-128, 50], [-128, 29]]
-      ]
+        [
+          [-118.163, 34.162],
+          [-118.108, 34.162],
+          [-118.108, 34.173],
+          [-118.163, 34.173],
+          [-118.163, 34.162],
+        ],
+      ],
     },
-    spatialPredicate: 'ST_EnvelopeIntersects'
+    spatialPredicate: 'ST_Contains',
+  };
+  run('trees', options, 12, t);
+});
+
+test('With a ST_Within geometry predicate', (t) => {
+  const options = {
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-118.163, 34.162],
+          [-118.108, 34.162],
+          [-118.108, 34.173],
+          [-118.163, 34.173],
+          [-118.163, 34.162],
+        ],
+      ],
+    },
+    spatialPredicate: 'ST_Within',
+  };
+  run('trees', options, 12, t);
+});
+
+test('With a ST_EnvelopeIntersects geometry predicate', (t) => {
+  const options = {
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-128, 29],
+          [-108, 29],
+          [-108, 50],
+          [-128, 50],
+          [-128, 29],
+        ],
+      ],
+    },
+    spatialPredicate: 'ST_EnvelopeIntersects',
   };
   run('states', options, 2, t);
 });
 
-test('With a ST_Intersects geometry predicate', t => {
+test('With a ST_Intersects geometry predicate', (t) => {
   const options = {
     geometry: {
       type: 'LineString',
-      coordinates: [[-85.983201784023521, 34.515410848143297, 204.5451898127248], [-121.278821256198796, 39.823566607727578, 1173.189682061974963]]
+      coordinates: [
+        [-85.983201784023521, 34.515410848143297, 204.5451898127248],
+        [-121.278821256198796, 39.823566607727578, 1173.189682061974963],
+      ],
     },
-    spatialPredicate: 'ST_Intersects'
+    spatialPredicate: 'ST_Intersects',
   };
   run('states', options, 1, t);
 });
 
-test('With a where and a geometry option', t => {
+test('With a where and a geometry option', (t) => {
   const options = {
     where: 'Genus like \'%Quercus%\'',
     geometry: {
       type: 'Polygon',
-      coordinates: [[[-118.163, 34.162], [-118.108, 34.162], [-118.108, 34.173], [-118.163, 34.173], [-118.163, 34.162]]]
-    }
+      coordinates: [
+        [
+          [-118.163, 34.162],
+          [-118.108, 34.162],
+          [-118.108, 34.173],
+          [-118.163, 34.173],
+          [-118.163, 34.162],
+        ],
+      ],
+    },
   };
   run('trees', options, 5, t);
 });
 
-test('With a where, geometry, limit and offset option', t => {
+test('With a where, geometry, limit and offset option', (t) => {
   t.plan(5);
   const data = 'trees';
   const options = {
     where: 'Genus like \'%Quercus%\'',
     geometry: {
       type: 'Polygon',
-      coordinates: [[[-118.163, 34.162], [-118.108, 34.162], [-118.108, 34.173], [-118.163, 34.173], [-118.163, 34.162]]]
+      coordinates: [
+        [
+          [-118.163, 34.162],
+          [-118.108, 34.162],
+          [-118.108, 34.173],
+          [-118.163, 34.173],
+          [-118.163, 34.162],
+        ],
+      ],
     },
     limit: 4,
-    offset: 1
+    offset: 1,
   };
   const features = require(`./fixtures/${data}.json`).features;
   const filtered = winnow.query(features, options);
@@ -383,7 +427,7 @@ test('With a where, geometry, limit and offset option', t => {
   t.equal(filtered[3].properties.Trunk_Diameter, 18);
 });
 
-test('With an envelope, an inSR and an outSR', t => {
+test('With an envelope, an inSR and an outSR', (t) => {
   const options = {
     f: 'json',
     returnGeometry: true,
@@ -395,18 +439,18 @@ test('With an envelope, an inSR and an outSR', t => {
       ymax: 4051582,
       spatialReference: {
         wkid: 102100,
-        latestWkid: 3857
-      }
+        latestWkid: 3857,
+      },
     },
     geometryType: 'esriGeometryEnvelope',
     inSR: 102100,
     outFields: '*',
-    outSR: 102100
+    outSR: 102100,
   };
   run('trees', options, 6, t);
 });
 
-test('With a multi-ring geometry and an inSR', t => {
+test('With a multi-ring geometry and an inSR', (t) => {
   const options = {
     geometry: {
       rings: [
@@ -415,24 +459,24 @@ test('With a multi-ring geometry and an inSR', t => {
           [19930537.269606635, 13148258.807095852],
           [20037508.342788905, 13148258.807095852],
           [20037508.342788905, -1018885.7633881811],
-          [19930537.269606635, -1018885.7633881811]
+          [19930537.269606635, -1018885.7633881811],
         ],
         [
           [-20037508.342788905, -1018885.7633881811],
           [-20037508.342788905, 13148258.807095852],
           [-4568447.54013514, 13148258.807095852],
           [-4568447.54013514, -1018885.7633881811],
-          [-20037508.342788905, -1018885.7633881811]
-        ]
-      ]
+          [-20037508.342788905, -1018885.7633881811],
+        ],
+      ],
     },
     geometryType: 'esriGeometryPolygon',
-    inSR: 102100
+    inSR: 102100,
   };
   run('ringbug', options, 30, t);
 });
 
-test('with a coded value domain', t => {
+test('with a coded value domain', (t) => {
   const options = {
     where: 'State = \'1\'',
     esriFields: [
@@ -450,22 +494,22 @@ test('with a coded value domain', t => {
           codedValues: [
             {
               name: 'Virginia',
-              code: '1'
+              code: '1',
             },
             {
               name: 'Maryland',
-              code: '2'
-            }
-          ]
+              code: '2',
+            },
+          ],
         },
-        defaultValue: null
-      }
-    ]
+        defaultValue: null,
+      },
+    ],
   };
   run('cvd', options, 2, t);
 });
 
-test('with a numeric coded value domain', t => {
+test('with a numeric coded value domain', (t) => {
   const options = {
     where: 'State = 1',
     esriFields: [
@@ -483,25 +527,25 @@ test('with a numeric coded value domain', t => {
           codedValues: [
             {
               name: 'Virginia',
-              code: 1
+              code: 1,
             },
             {
               name: 'Maryland',
-              code: 2
-            }
-          ]
+              code: 2,
+            },
+          ],
         },
-        defaultValue: null
-      }
-    ]
+        defaultValue: null,
+      },
+    ],
   };
   run('cvd', options, 2, t);
 });
 
-test('with a coded value domain', t => {
+test('with a coded value domain', (t) => {
   const options = {
     where: 'ZONING_S = \'INST\'',
-    esriFields: require('./fixtures/esriFields.json')
+    esriFields: require('./fixtures/esriFields.json'),
   };
 
   t.plan(1);
@@ -511,60 +555,94 @@ test('with a coded value domain', t => {
   t.equal(filtered.length, 1);
 });
 
-test('with a date query', t => {
+test('with a date query', (t) => {
   const options = {
-    where: 'survey_date >= date 2017-02-05'
+    where: 'survey_date >= date 2017-02-05',
   };
   run('trees', options, 4, t);
 });
 
-test('with an esri-style date query', t => {
+test('with an esri-style date query', (t) => {
   const options = {
-    where: 'survey_date >= \'2017-02-05T00:00:00.000Z\' AND survey_date <= \'2017-03-06T23:59:59.000Z\''
+    where:
+      'survey_date >= \'2017-02-05T00:00:00.000Z\' AND survey_date <= \'2017-03-06T23:59:59.000Z\'',
   };
   run('trees', options, 4, t);
 });
 
-test('with a timestamp query', t => {
+test('with a timestamp query', (t) => {
   const options = {
-    where: 'survey_date >= timestamp \'2017-02-05\''
+    where: 'survey_date >= timestamp \'2017-02-05\'',
   };
   run('trees', options, 4, t);
 });
 
-test('with a between query', t => {
+test('with a between query', (t) => {
   const options = {
-    where: 'survey_date between timestamp \'2017-01-06T00:00:00.000Z\' AND timestamp \'2017-02-06T23:59:59.000Z\''
+    where:
+      'survey_date between timestamp \'2017-01-06T00:00:00.000Z\' AND timestamp \'2017-02-06T23:59:59.000Z\'',
   };
   run('trees', options, 2, t);
 });
 
-test('with escaped single quote in query', t => {
+test('with escaped single quote in query', (t) => {
   const options = {
-    where: 'Street_Name = \'GRAND\\\'S STREET\\\'S\''
+    where: 'Street_Name = \'GRAND\'\'S STREET\'\'S\'',
   };
   run('trees', options, 1, t);
 });
 
-test('with a OBJECTID query on data that requires dynamic OBJECTID generation', t => {
+test('with a OBJECTID query on data that requires dynamic OBJECTID generation', (t) => {
   t.plan(1);
   const options = {
     where: 'OBJECTID=1138516379',
-    toEsri: true
+    toEsri: true,
   };
   const fixtures = _.cloneDeep(require('./fixtures/snow.json'));
   const filtered = winnow.query(fixtures, options);
   t.equal(filtered.features.length, 1);
 });
 
-test('with null dates in data source', t => {
+test('with a OBJECTID query on data that requires dynamic OBJECTID generation', (t) => {
+  t.plan(1);
+  const options = {
+    toEsri: true,
+  };
+  const fixtures = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {
+          OBJECTID: 11303,
+          Common_Name: 'SOUTHERN MAGNOLIA',
+          survey_date: '2017-01-05T00:00:00.000Z',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-118.16230746759626, 34.137113646321595],
+        },
+      },
+    ],
+  };
+  const queryResult = winnow.query(fixtures, options);
+  const objectId = queryResult.features[0].attributes.OBJECTID;
+  const filteredResult = winnow.query(fixtures, {
+    toEsri: true,
+    where: `OBJECTID = ${objectId}`
+  });
+  t.equal(filteredResult.features.length, 1);
+});
+
+test('with null dates in data source', (t) => {
   // Ensure null dates are returned as null, not as 0
   // Bug only occurs when:
   // * 'toEsri' option enabled
   // * the geojson is passed to winnow.query with the metadata.fields populated
   const options = {
-    where: 'Date1 >= timestamp \'2020-01-05 00:00:00\' AND Date1 <= timestamp \'2020-02-08 23:59:59\'',
-    toEsri: true
+    where:
+      'Date1 >= timestamp \'2020-01-05 00:00:00\' AND Date1 <= timestamp \'2020-02-08 23:59:59\'',
+    toEsri: true,
   };
   t.plan(4);
   const fixtures = _.cloneDeep(require('./fixtures/dates.json'));
@@ -577,7 +655,7 @@ test('with null dates in data source', t => {
   t.equal(feature.attributes.Date6, null);
 });
 
-function run (data, options, expected, t) {
+function run(data, options, expected, t) {
   t.plan(1);
   const fixtures = _.cloneDeep(require(`./fixtures/${data}.json`));
   const features = fixtures.features;

--- a/packages/winnow/test/integration/to-esri.spec.js
+++ b/packages/winnow/test/integration/to-esri.spec.js
@@ -70,7 +70,7 @@ test('checking if an object id exists', t => {
   };
   const fixture = _.cloneDeep(oidFeature);
   const result = Winnow.query(fixture, options);
-  t.equal(result.features[0].attributes.OBJECTID, 1430702552);
+  t.equal(result.features[0].attributes.OBJECTID, 1738126944);
   t.equal(result.metadata.idField, undefined);
   t.end();
 });
@@ -103,7 +103,7 @@ test('adding an object id', t => {
   try {
     // If requiring farmhash is successful we use that hash
     require('farmhash');
-    hash = 239375164;
+    hash = 1301409517;
   } catch (e) {
     // Else use the string-hash number
     hash = 1729830217;


### PR DESCRIPTION
The numeric hash of a feature to create an OBJECTID (as part of the SQL `SELECT`) has to occur before any transformation of ISO date-strings to epoch times (required to create Esri JSON).  This is critical because any `WHERE` clause that includes the OBJECTID comparison must also hash each feature to evaluate the comparison, and these features don't include the date transformation.   