### PR TITLE
feat: private model props

### DIFF
--- a/.changeset/cyan-apricots-tie.md
+++ b/.changeset/cyan-apricots-tie.md
@@ -2,4 +2,6 @@
 '@koopjs/koop-core': minor
 ---
 
-- make 'cache', 'before', and 'after' private props
+- make 'cache', 'before', and 'after' private model props
+- add `cacheSize` option
+- add `cacheTtl` option for provider registration

--- a/.changeset/cyan-apricots-tie.md
+++ b/.changeset/cyan-apricots-tie.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': minor
+---
+
+- make 'cache', 'before', and 'after' private props

--- a/demo/provider-data/point-cached.geojson
+++ b/demo/provider-data/point-cached.geojson
@@ -1,0 +1,19 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "ttl": 30
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -104.9476,
+          39.9448
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21740,6 +21740,7 @@
         "@koopjs/cache-memory": "5.0.0",
         "@koopjs/logger": "5.0.0",
         "@koopjs/output-geoservices": "7.0.0",
+        "@sindresorhus/fnv1a": "^2.0.1",
         "body-parser": "^1.19.0",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -21756,6 +21757,14 @@
         "should-sinon": "0.0.6",
         "sinon": "^15.0.0",
         "supertest": "^6.3.1"
+      }
+    },
+    "packages/koop-core/node_modules/@sindresorhus/fnv1a": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/fnv1a/-/fnv1a-2.0.1.tgz",
+      "integrity": "sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/koop-logger": {
@@ -24205,6 +24214,7 @@
         "@koopjs/cache-memory": "5.0.0",
         "@koopjs/logger": "5.0.0",
         "@koopjs/output-geoservices": "7.0.0",
+        "@sindresorhus/fnv1a": "2",
         "body-parser": "^1.19.0",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -24219,6 +24229,13 @@
         "should-sinon": "0.0.6",
         "sinon": "^15.0.0",
         "supertest": "^6.3.1"
+      },
+      "dependencies": {
+        "@sindresorhus/fnv1a": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/fnv1a/-/fnv1a-2.0.1.tgz",
+          "integrity": "sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw=="
+        }
       }
     },
     "@koopjs/logger": {

--- a/packages/koop-core/README.md
+++ b/packages/koop-core/README.md
@@ -94,6 +94,44 @@ const options = {
 }
 ```
 
+### Registering Providers
+When registering a provider you can pass an options object that provides some useful functionality:
+
+```js
+const Koop = require('@koopjs/koop-core')
+const koop = new Koop()
+
+const providerOptions = {
+  name: 'special-name',
+  cacheTtl: 600,
+  before: (req, callback) => {
+    req.query.myHardCodedParam = 'foo';
+    callback();
+  }
+  after: (req, geojson, callback) => {
+    geojson.crs = 'my coordinate system';
+    callback(null, geojson);
+  }
+}
+
+/* Register Koop data providers with options */
+const provider = require('@koopjs/provider-github')
+koop.register(provider, providerOptions)
+```
+
+#### Provider registration options
+##### name
+Use this param to override the name of the provider.  If you supply a value for `name` it will be used in the path for routes registered to this provider.
+
+##### cacheTtl
+Use this param to set the default caching time (in seconds) for any data acquired by this provider. It can be overridden on a request-by-request basis by adding a `ttl` property to the root level of the geojson produced by the provider.
+
+##### before
+Supply a function that is executed _before_ a provider's `getData` method and has access to the Express request object.  This is useful is you want to modify incoming request params before they arrive in a providers `getData` method.
+
+##### after
+Supply a function that is executed _after_ a provider's `getData` method and has access to the Express request object.  This is useful is you want to modify the GeoJSON produce by the provider before it is passed on to the cache or any output plugin.  It's a way of modifying a provider's getData functionality without having to modify the code of the provider itself.
+
 ## Issues
 
 Find a bug or want to request a new feature? Please let us know by submitting an [issue](https://github.com/koopjs/koop/issues).

--- a/packages/koop-core/coverage.svg
+++ b/packages/koop-core/coverage.svg
@@ -1,20 +1,20 @@
-<svg width="96.3" height="20" viewBox="0 0 963 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 93%">
-  <title>coverage: 93%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.88%">
+  <title>coverage: 92.88%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="m"><rect width="963" height="200" rx="30" fill="#FFF"/></mask>
+  <mask id="m"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="603" height="200" fill="#555"/>
-    <rect width="360" height="200" fill="#97c40f" x="603"/>
-    <rect width="963" height="200" fill="url(#a)"/>
+    <rect width="540" height="200" fill="#97c40f" x="603"/>
+    <rect width="1143" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="260" fill="#000" opacity="0.25">93%</text>
-    <text x="648" y="138" textLength="260">93%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.88%</text>
+    <text x="648" y="138" textLength="440">92.88%</text>
   </g>
   
 </svg>

--- a/packages/koop-core/coverage.svg
+++ b/packages/koop-core/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 92.88%">
-  <title>coverage: 92.88%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.42%">
+  <title>coverage: 94.42%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">92.88%</text>
-    <text x="648" y="138" textLength="440">92.88%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.42%</text>
+    <text x="648" y="138" textLength="440">94.42%</text>
   </g>
   
 </svg>

--- a/packages/koop-core/package.json
+++ b/packages/koop-core/package.json
@@ -22,6 +22,7 @@
     "@koopjs/cache-memory": "5.0.0",
     "@koopjs/logger": "5.0.0",
     "@koopjs/output-geoservices": "7.0.0",
+    "@sindresorhus/fnv1a": "^2.0.1",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "config": "^3.3.9",

--- a/packages/koop-core/src/index.js
+++ b/packages/koop-core/src/index.js
@@ -104,7 +104,6 @@ Koop.prototype._registerAuth = function (auth) {
 Koop.prototype._registerProvider = function (provider, options = {}) {
   const providerRegistration = ProviderRegistration.create({ koop: this, provider, options });
   this.providers.push(providerRegistration);
-  this.log.info('registered provider:', providerRegistration.namespace, providerRegistration.version);
 };
 
 /**
@@ -115,7 +114,7 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
  */
 Koop.prototype._registerOutput = function (outputClass, options) {
   this.outputs.push({ outputClass, options });
-  this.log.info('registered output:', outputClass.name, outputClass.version);
+  this.log.info(`registered output: ${outputClass.name} ${outputClass.version}`);
 };
 
 /**

--- a/packages/koop-core/src/index.spec.js
+++ b/packages/koop-core/src/index.spec.js
@@ -71,12 +71,11 @@ describe('Index tests', function () {
       const koop = new Koop({ logLevel: 'error' });
       koop.register(provider, { foo: 'bar' });
       const registeredProvider = koop.providers.find(provider => { return provider.namespace === 'test-provider'; });
-      registeredProvider.model.should.have.property('cache');
       registeredProvider.model.should.have.property('options');
       registeredProvider.model.options.should.have.property('foo', 'bar');
     });
 
-    it('should register successfully and attach optional custom cache to model', function () {
+    it('should register successfully and pass optional cache to model', function () {
       const koop = new Koop({ logLevel: 'error' });
       koop.register(provider, {
         cache: {
@@ -86,8 +85,8 @@ describe('Index tests', function () {
         }
       });
       const registeredProvider = koop.providers.find(provider => { return provider.namespace === 'test-provider'; });
-      registeredProvider.model.should.have.property('cache');
-      registeredProvider.model.cache.should.have.property('customFunction').and.be.a.Function();
+      registeredProvider.model.options.should.have.property('cache');
+      registeredProvider.model.options.cache.should.have.property('customFunction').and.be.a.Function();
     });
 
     it('should reject cache option missing an insert method', function () {
@@ -126,17 +125,6 @@ describe('Index tests', function () {
       } catch (err) {
         err.should.have.property('message', 'Provider options ValidationError: "routePrefix" must be a string');
       }
-    });
-
-    it('should register successfully and attach optional "before" and "after" function to model', function () {
-      const koop = new Koop({ logLevel: 'error' });
-      koop.register(provider, {
-        before: (req, next) => {}, // eslint-disable-line -- this allow validation to occur
-        after: (req, data, callback) => {} // eslint-disable-line -- this allow validation to occur
-      });
-      const registeredProvider = koop.providers.find(provider => { return provider.namespace === 'test-provider'; });
-      registeredProvider.model.should.have.property('before').and.be.a.Function();
-      registeredProvider.model.should.have.property('after').and.be.a.Function();
     });
 
     it('should reject optional "before" function that does not have correct arity', function () {

--- a/packages/koop-core/src/provider-registration/create-model.spec.js
+++ b/packages/koop-core/src/provider-registration/create-model.spec.js
@@ -31,7 +31,7 @@ describe('Tests for create-model', function () {
       const model = createModel({ ProviderModel: Model, koop: koopMock }, {
         foo: 'bar'
       });
-      model.koop.should.deepEqual({...koopMock, foo: 'bar' });
+      model.koop.should.deepEqual({...koopMock });
       model.options.should.deepEqual({ foo: 'bar' });
     });
 
@@ -47,7 +47,7 @@ describe('Tests for create-model', function () {
       const model = createModel({ ProviderModel: Model, koop: koopMock }, {
         foo: 'bar'
       });
-      model.koop.should.deepEqual({...koopMock, foo: 'bar' });
+      model.koop.should.deepEqual(koopMock);
       model.options.should.deepEqual({ foo: 'bar' });
     });
   });

--- a/packages/koop-core/src/provider-registration/index.js
+++ b/packages/koop-core/src/provider-registration/index.js
@@ -21,6 +21,7 @@ module.exports = class ProviderRegistration {
   static create (params) {
     const provider = new ProviderRegistration(params);
     provider.registerRoutes(params.koop.server);
+    params.koop.log.info(`registered provider: ${provider.namespace} v${provider.version}`);
     provider.logRoutes();
     return provider;
   }

--- a/packages/koop-core/test/fixtures/fake-provider/models/fake.js
+++ b/packages/koop-core/test/fixtures/fake-provider/models/fake.js
@@ -1,4 +1,5 @@
-function Fake () {
+function Fake (koop, options) {
+  this.options = options;
   this.find = function find (id, options, callback) {
     callback(null, [{}]);
   };

--- a/packages/koop-core/test/fixtures/fake-provider/models/fake.js
+++ b/packages/koop-core/test/fixtures/fake-provider/models/fake.js
@@ -11,4 +11,17 @@ Fake.prototype.getData = function getData (req, callback) {
     features: []
   });
 };
+
+Fake.prototype.getLayer = function getData (req, callback) {
+  callback(null, {
+    layer: 'foo'
+  });
+};
+
+Fake.prototype.getCatalog = function getData (req, callback) {
+  callback(null, {
+    catalog: 'foo'
+  });
+};
+
 module.exports = Fake;


### PR DESCRIPTION
- Add cacheSize options to Koop instance options; this will override the default LRU cache size (500)
- Add cacheTtl options to provider registration options; if set, this is the default cache time for any data from a given provider
- - Make some model props private; these will still be available in the provider's class methods.