### PR TITLE
chore: add mock logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cov:compile:unit": "nyc merge packages/cache-memory/.nyc_output .nyc_output_unit/cache-memory.json && nyc merge packages/featureserver/.nyc_output_unit .nyc_output_unit/featureserver.json && nyc merge packages/koop-core/.nyc_output .nyc_output_unit/koop-core.json && nyc merge packages/logger/.nyc_output .nyc_output_unit/logger.json && nyc merge packages/output-geoservices/.nyc_output .nyc_output_unit/output-geoservices.json && nyc merge packages/winnow/.nyc_output_unit .nyc_output_unit/winnow.json",
     "cov:report": "nyc report --reporter=html",
     "cov:report:unit": "nyc report --temp-dir=.nyc_output_unit --report-dir=coverage_unit --reporter=html",
-    "test:e2e": "DATA_DIR=./test/provider-data jest ./test/*.spec.js",
+    "test:e2e": "SUPPRESS_NO_CONFIG_WARNING=true DATA_DIR=./test/provider-data jest ./test/*.spec.js",
     "version": "changeset version",
     "release:npm": "changeset publish",
     "release:github": "node gh-release.js",

--- a/test/geoservice-error-handling.spec.js
+++ b/test/geoservice-error-handling.spec.js
@@ -1,11 +1,18 @@
 const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 const request = require('supertest');
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  silly: () => {},
+  warn: () => {},
+  error: () => {}
+};
 
 describe('geoservices error handling', () => {
   describe('handle errors coming from pull-data calls in generalHandler', () => {
     test('should return provider 500 error', async () => {
-      const koop = new Koop({ logLevel: 'error' });
+      const koop = new Koop({ logLevel: 'error', logger: mockLogger });
       koop.register(provider, {
         dataDir: './test/provider-data',
         before: (req, callback) => { // eslint-disable-line
@@ -31,7 +38,7 @@ describe('geoservices error handling', () => {
     });
 
     test('should return 499 error', async () => {
-      const koop = new Koop({ logLevel: 'error' });
+      const koop = new Koop({ logLevel: 'error', logger: mockLogger });
       let auth = require('@koopjs/auth-direct-file')(
         'pass-in-your-secret',
         `${__dirname}/helpers/user-store.json`,
@@ -60,7 +67,7 @@ describe('geoservices error handling', () => {
     });
 
     test('should return 498 error', async () => {
-      const koop = new Koop({ logLevel: 'error' });
+      const koop = new Koop({ logLevel: 'error', logger: mockLogger });
       let auth = require('@koopjs/auth-direct-file')(
         'pass-in-your-secret',
         `${__dirname}/helpers/user-store.json`,
@@ -91,7 +98,7 @@ describe('geoservices error handling', () => {
 
   describe('handle errors coming from authenticate calls in generateToken', () => {
     test('should return 498 error', async () => {
-      const koop = new Koop({ logLevel: 'error' });
+      const koop = new Koop({ logLevel: 'error', logger: mockLogger });
       let auth = require('@koopjs/auth-direct-file')(
         'pass-in-your-secret',
         `${__dirname}/helpers/user-store.json`,

--- a/test/geoservice-query.spec.js
+++ b/test/geoservice-query.spec.js
@@ -1,9 +1,16 @@
 const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 const request = require('supertest');
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  silly: () => {},
+  warn: () => {},
+  error: () => {}
+};
 
 describe('koop', () => {
-  const koop = new Koop({ logLevel: 'error' });
+  const koop = new Koop({ logLevel: 'error', logger: mockLogger });
   koop.register(provider, { dataDir: './test/provider-data' });
   test('should return true', async () => {
     try {


### PR DESCRIPTION
Add mock-logger in E2E test to prevents confusing logs during test runs.