### PR TITLE
fix: need logger dep in winnow package

### DIFF
--- a/.changeset/hungry-tips-switch.md
+++ b/.changeset/hungry-tips-switch.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/winnow': patch
+---
+
+- need logger dep for stand alone usage

--- a/.github/workflows/synk-dep-check.yml
+++ b/.github/workflows/synk-dep-check.yml
@@ -2,8 +2,6 @@ name: Snyk Dep Check
 on:
   pull_request:
     branches: [ "master", "next" ]
-    paths:
-      - "**/packages/**.js"
   schedule:
     - cron: '35 13 * * 6'
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19400,6 +19400,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/proj-codes": "^3.1.0",
+        "@koopjs/logger": "^5.0.0",
         "@terraformer/arcgis": "^2.1.1",
         "@terraformer/spatial": "^2.1.2",
         "@turf/bbox-polygon": "^6.5.0",

--- a/packages/winnow/package.json
+++ b/packages/winnow/package.json
@@ -49,6 +49,7 @@
   "homepage": "https://github.com/koopjs/koop#readme",
   "dependencies": {
     "@esri/proj-codes": "^3.1.0",
+    "@koopjs/logger": "5.0.0",
     "@terraformer/arcgis": "^2.1.1",
     "@terraformer/spatial": "^2.1.2",
     "@turf/bbox-polygon": "^6.5.0",


### PR DESCRIPTION
Winnow is missing the @koopjs/logger dep in its package.json.  This would likely cause a runtime error if winnow package was used as a standalone.