### PR TITLE
Acquire logger at request time in FeatureServer and Winnow

### DIFF
--- a/.changeset/funny-beds-doubt.md
+++ b/.changeset/funny-beds-doubt.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- logger needs to be acquired at request time

--- a/.changeset/gold-islands-perform.md
+++ b/.changeset/gold-islands-perform.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/winnow': patch
+---
+
+- logger needs to be acquired at request time

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,6 +1,6 @@
 const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 
-const koop = new Koop({ });
+const koop = new Koop({ logLevel: 'debug' });
 koop.register(provider, { dataDir: './demo/provider-data'});
 koop.server.listen(8080);

--- a/packages/featureserver/src/helpers/calculate-extent.js
+++ b/packages/featureserver/src/helpers/calculate-extent.js
@@ -1,5 +1,5 @@
 const { calculateBounds } = require('@terraformer/spatial');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const normalizeExtent = require('./normalize-extent');
 
 function calculateExtent ({ isLayer, geojson, spatialReference }) {
@@ -11,7 +11,7 @@ function calculateExtent ({ isLayer, geojson, spatialReference }) {
     const bounds = calculateBounds(geojson);
     return normalizeExtent(bounds, spatialReference);
   } catch (error) {
-    logger.debug(`Could not calculate extent from data: ${error.message}`);
+    logManager.logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 

--- a/packages/featureserver/src/helpers/feature-layer-metadata.js
+++ b/packages/featureserver/src/helpers/feature-layer-metadata.js
@@ -6,7 +6,7 @@ const {
   PolygonRenderer
 } = require('./renderers');
 const { calculateBounds } = require('@terraformer/spatial');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const getSpatialReference = require('./get-spatial-reference');
 const getGeometryTypeFromGeojson = require('./get-geometry-type-from-geojson');
 const normalizeExtent = require('./normalize-extent');
@@ -113,7 +113,7 @@ function calculateExtentFromFeatures (geojson, spatialReference) {
       spatialReference
     };
   } catch (error) {
-    logger.debug(`Could not calculate extent from data: ${error.message}`);
+    logManager.logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 

--- a/packages/featureserver/src/helpers/fields/fields.js
+++ b/packages/featureserver/src/helpers/fields/fields.js
@@ -5,7 +5,7 @@ const {
   FieldFromFieldDefinition,
   ObjectIdFieldFromDefinition
 } = require('./field-classes');
-const { logger } = require('../../logger');
+const logManager = require('../../logger');
 
 class Fields {
   static normalizeOptions (inputOptions) {
@@ -35,7 +35,7 @@ class Fields {
     } = options;
 
     if (shouldWarnAboutMissingIdFieldDefinition(idField, fieldDefinitions)) {
-      logger.debug(`provider's "idField" is set to ${idField}, but this field is not found in field-definitions`);
+      logManager.logger.debug(`provider's "idField" is set to ${idField}, but this field is not found in field-definitions`);
     }
 
     const normalizedIdField = idField || 'OBJECTID';

--- a/packages/featureserver/src/helpers/get-geometry-type-from-geojson.js
+++ b/packages/featureserver/src/helpers/get-geometry-type-from-geojson.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 
 const esriLookup = {
   Point: 'esriGeometryPoint',
@@ -18,7 +18,7 @@ module.exports = function getGeometryTypeFromGeojson ({ geometryType, metadata =
   const type = geometryType || metadata.geometryType || findInFeatures(features);
 
   if (!type) {
-    logger.debug(`Input JSON has unsupported geometryType: ${type}`);
+    logManager.logger.debug(`Input JSON has unsupported geometryType: ${type}`);
   }
   return esriLookup[type];
 };

--- a/packages/featureserver/src/helpers/normalize-spatial-reference.js
+++ b/packages/featureserver/src/helpers/normalize-spatial-reference.js
@@ -1,7 +1,7 @@
 const esriProjCodes = require('@esri/proj-codes');
 const Joi = require('joi');
 const wktParser = require('wkt-parser');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const wktLookup = new Map();
 const schema = Joi.alternatives(
   Joi.string(),
@@ -19,7 +19,7 @@ function normalizeSpatialReference (input) {
   const { error } = schema.validate(input);
 
   if (error) {
-    logger.verbose(` ${input} is not a valid spatial reference; defaulting to none, error: ${error}`);
+    logManager.logger.verbose(` ${input} is not a valid spatial reference; defaulting to none, error: ${error}`);
 
     // Todo: throw error
     return { wkid: 4326, latestWkid: 4326 };
@@ -81,7 +81,7 @@ function esriWktLookup (lookupValue) {
 
   if (!result) {
     // Todo - throw error
-    logger.verbose(`An unknown spatial reference was detected: ${lookupValue}; defaulting to none`);
+    logManager.logger.verbose(`An unknown spatial reference was detected: ${lookupValue}; defaulting to none`);
     return;
   }
 
@@ -99,7 +99,7 @@ function convertStringToSpatialReference (wkt) {
     const wkid = getWktWkid(wkt);
     return wktLookup.get(wkid) || esriWktLookup(wkid) || { wkt };
   } catch (err) {
-    logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
+    logManager.logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }

--- a/packages/featureserver/src/helpers/server-metadata.js
+++ b/packages/featureserver/src/helpers/server-metadata.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const wktParser = require('wkt-parser');
 const projCodes = require('@esri/proj-codes');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const esriUnitsLookup = require('./esri-units-lookup');
 const defaults = require('../metadata-defaults');
 
@@ -62,7 +62,7 @@ function getUnits({ latestWkid, wkid, wkt }) {
     const units = wktParser(wkt)?.units;
     return esriUnitsLookup(units);
   } catch (error) {
-    logger.debug(
+    logManager.logger.debug(
       `Could not set feature service units from spatial reference: ${error}`,
     );
   }

--- a/packages/featureserver/src/helpers/validate-inputs.js
+++ b/packages/featureserver/src/helpers/validate-inputs.js
@@ -1,7 +1,8 @@
 const joi = require('joi');
+const _ = require('lodash');
 const geojsonhint = require('geojson-validation');
-const { logger } = require('../logger');
-const { KOOP_LOG_LEVEL, LOG_LEVEL } = process.env;
+const logManager = require('../logger');
+const { VALIDATE_GEOJSON } = process.env;
 
 const queryParamSchema = joi
   .object({
@@ -26,13 +27,14 @@ function validate(params, geojson) {
 }
 
 function shouldValidateGeojson() {
-  return LOG_LEVEL === 'debug' || KOOP_LOG_LEVEL === 'debug';
+  return !_.isUndefined(VALIDATE_GEOJSON);
 }
 
+// TODO: move this out of feature server
 function validateGeojson(geojson) {
   const geojsonErrors = geojsonhint.valid(geojson, true);
   if (geojsonErrors.length > 0) {
-    logger.debug(
+    logManager.logger.debug(
       `source data for contains invalid GeoJSON; ${geojsonErrors[0]}`,
     );
   }

--- a/packages/featureserver/src/helpers/validate-inputs.spec.js
+++ b/packages/featureserver/src/helpers/validate-inputs.spec.js
@@ -12,29 +12,8 @@ describe('validateInputs', () => {
 
     const debugSpy = sinon.spy();
 
-
-
-    it('should validate geojson when LOG_LEVEL === debug', () => {
-      process.env.LOG_LEVEL = 'debug';
-
-      const { validateInputs } = proxyquire('./validate-inputs', {
-        'geojson-validation': {
-          valid: hintSpy
-        },
-        '../logger': {
-          logger: {
-            debug: debugSpy
-          }
-        }
-      });
-      validateInputs({}, { foo: 'geojson' });
-      hintSpy.calledOnce.should.equal(true);
-      hintSpy.firstCall.args.should.deepEqual([{ foo: 'geojson' }, true]);
-      debugSpy.calledOnce.should.equal(true);
-    });
-
-    it('should validate geojson when KOOP_LOG_LEVEL === debug', () => {
-      process.env.KOOP_LOG_LEVEL = 'debug';
+    it('should validate geojson when VALIDATE_GEOJSON is defined', () => {
+      process.env.VALIDATE_GEOJSON = '';
 
       const { validateInputs } = proxyquire('./validate-inputs', {
         'geojson-validation': {
@@ -51,6 +30,7 @@ describe('validateInputs', () => {
       hintSpy.calledOnce.should.equal(true);
       hintSpy.firstCall.args.should.deepEqual([{ foo: 'geojson' }, true]);
       debugSpy.calledOnce.should.equal(true);
+      delete process.env.VALIDATE_GEOJSON;
     });
 
     it('should skip geojson validation', () => {

--- a/packages/featureserver/src/logger/index.js
+++ b/packages/featureserver/src/logger/index.js
@@ -1,21 +1,22 @@
-let logger = require('./logger');
-const Logger = require('@koopjs/logger');
+const Logger = require('@koopjs/logger'); 
+let logger = new Logger();
 const winnow = require('@koopjs/winnow');
 
 module.exports = {
-  logger,
-  setLogger,
+  get logger () {
+    return logger;
+  },
+
+  setLogger: ({ logger: _logger, logLevel }) => {
+    if (_logger) {
+      logger = _logger;
+      logger.silly('FeatureServer no longer using default logger.');
+      winnow.setLogger({ logger });
+      return;
+    }
+  
+    if (logLevel) {
+      logger = new Logger({ logLevel });
+    }
+  }
 };
-
-function setLogger({ logger: _logger, logLevel }) {
-  if (_logger) {
-    logger = _logger;
-    logger.silly('FeatureServer no longer using default logger.');
-    winnow.setLogger({ logger });
-    return;
-  }
-
-  if (logLevel) {
-    logger = new Logger({ logLevel });
-  }
-}

--- a/packages/featureserver/src/logger/logger.js
+++ b/packages/featureserver/src/logger/logger.js
@@ -1,5 +1,0 @@
-const Logger = require('@koopjs/logger'); 
-let _logger = new Logger();
-
-module.exports =  _logger;
-

--- a/packages/featureserver/src/query/log-warnings.js
+++ b/packages/featureserver/src/query/log-warnings.js
@@ -1,19 +1,19 @@
 const _ = require('lodash');
 const { getDataTypeFromValue } = require('../helpers');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 
 function logWarnings(geojson, format) {
   const { metadata = {}, features } = geojson;
   const esriFormat = format !== geojson;
 
   if (esriFormat && !metadata.idField) {
-    logger.debug(
+    logManager.logger.debug(
       'requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.',
     );
   }
 
   if (esriFormat && hasMixedCaseObjectIdKey(metadata.idField)) {
-    logger.debug(
+    logManager.logger.debug(
       'requested provider has "idField" that is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.',
     );
   }
@@ -35,7 +35,7 @@ function compareFieldDefintionsToFeature(fieldDefinitions, featureProperties) {
     const featureField = findFeatureProperty(featureProperties, name, alias);
 
     if (!featureField || hasTypeMismatch(type, featureField)) {
-      logger.debug(
+      logManager.logger.debug(
         `field definition "${name} (${type})" not found in first feature of provider's GeoJSON`,
       );
     }
@@ -47,7 +47,7 @@ function compareFeatureToFieldDefinitions(featureProperties, fieldDefinitions) {
     const definition = _.find(fieldDefinitions, ['name', key]) || _.find(fieldDefinitions, ['name', key]);
 
     if (!definition && key !== 'OBJECTID') {
-      logger.debug(
+      logManager.logger.debug(
         `requested provider has feature with property "${key}" that was not defined in metadata fields array`,
       );
     }

--- a/packages/featureserver/src/route.js
+++ b/packages/featureserver/src/route.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const layerInfo = require('./layer-metadata');
 const query = require('./query');
-const { logger } = require('./logger');
+const logManager = require('./logger');
 const queryRelatedRecords = require('./queryRelatedRecords.js');
 const generateRenderer = require('./generate-renderer');
 const restInfo = require('./rest-info-route-handler');
@@ -51,7 +51,7 @@ module.exports = function route(req, res, geojson = {}) {
 
     return responseHandler(req, res, 200, result);
   } catch (error) {
-    logger.debug(error);
+    logManager.logger.debug(error);
     const { code = 500 , message, details = [message] } = error;
     
     // Geoservice spec wraps all errors in a 200 response (!)

--- a/packages/featureserver/src/server-info-route-handler.js
+++ b/packages/featureserver/src/server-info-route-handler.js
@@ -7,7 +7,7 @@ const {
   normalizeSpatialReference,
   normalizeInputData,
 } = require('./helpers');
-const { logger } = require('./logger');
+const logManager = require('./logger');
 const ServerMetadata = require('./helpers/server-metadata');
 
 function serverMetadataResponse(data, req = {}) {
@@ -114,7 +114,7 @@ function calculateServiceExtentFromLayers(layers, spatialReference) {
       spatialReference,
     };
   } catch (error) {
-    logger.debug(`Could not calculate extent from data: ${error.message}`);
+    logManager.logger.debug(`Could not calculate extent from data: ${error.message}`);
   }
 }
 
@@ -131,7 +131,7 @@ function getExtent(extent, spatialReference) {
   try {
     return normalizeExtent(extent, spatialReference);
   } catch (error) {
-    logger.warn(`Could not normalize extent: ${ error }`);
+    logManager.logger.warn(`Could not normalize extent: ${ error }`);
   }
 }
 

--- a/packages/winnow/src/filter-and-transform/filters/hashed-objectid-comparator.js
+++ b/packages/winnow/src/filter-and-transform/filters/hashed-objectid-comparator.js
@@ -1,5 +1,5 @@
 const createIntegerHash = require('../helpers/create-integer-hash');
-const { logger } = require('../../logger');
+const logManager = require('../../logger');
 
 /**
  * This function is used when the where option includes an OBJECTID, but the data
@@ -45,6 +45,6 @@ module.exports = function (properties, geometry, value, operator) {
     return objectIdValues.includes(hashedFeature);
   }
   
-  logger.debug(`unsupported operator "${operator}"; ignoring`);
+  logManager.logger.debug(`unsupported operator "${operator}"; ignoring`);
   return false;
 };

--- a/packages/winnow/src/filter-and-transform/transforms/project.js
+++ b/packages/winnow/src/filter-and-transform/transforms/project.js
@@ -1,4 +1,4 @@
-const { logger } = require('../../logger');
+const logManager = require('../../logger');
 const projectCoordinates = require('../../helpers/project-coordinates');
 
 function project (geometry, sourceCoordinateSystem, targetCoordinateSystem) {
@@ -22,7 +22,7 @@ function tryProjectingGeometry ({ type, sourceCoordinates, sourceCoordinateSyste
       })
     };
   } catch (error) {
-    logger.debug(error);
+    logManager.logger.debug(error);
     // TODO: should we throw error instead of returning null?
     return null;
   }

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { logger } = require('../../logger');
+const logManager = require('../../logger');
 const { createIntegerHash } = require('../helpers');
 
 module.exports = function transformToEsriProperties (properties, geometry, delimitedDateFields, requiresObjectId, idField) {
@@ -13,7 +13,7 @@ module.exports = function transformToEsriProperties (properties, geometry, delim
   }
 
   if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
-    logger.debug(`OBJECTIDs created from provider's "idField" (${idField}: ${properties[idField]}) are not integers from 0 to 2147483647`);
+    logManager.logger.debug(`OBJECTIDs created from provider's "idField" (${idField}: ${properties[idField]}) are not integers from 0 to 2147483647`);
   }
 
   return transformProperties(properties, dateFields);

--- a/packages/winnow/src/logger/index.js
+++ b/packages/winnow/src/logger/index.js
@@ -1,19 +1,19 @@
-let logger = require('./logger');
 const Logger = require('@koopjs/logger');
+let logger = new Logger();
 
 module.exports = {
-  logger,
-  setLogger,
+  get logger () {
+    return logger;
+  },
+  setLogger: ({ logger: _logger, logLevel }) => {
+    if (_logger) {
+      logger = _logger;
+      logger.silly('Winnow no longer using default logger.');
+      return;
+    }
+  
+    if (logLevel) {
+      logger = new Logger({ logLevel });
+    }
+  }
 };
-
-function setLogger({ logger: _logger, logLevel }) {
-  if (_logger) {
-    logger = _logger;
-    logger.silly('Winnow no longer using default logger.');
-    return;
-  }
-
-  if (logLevel) {
-    logger = new Logger({ logLevel });
-  }
-}

--- a/packages/winnow/src/logger/logger.js
+++ b/packages/winnow/src/logger/logger.js
@@ -1,6 +1,0 @@
-const Logger = require('@koopjs/logger'); 
-let _logger = new Logger();
-
-
-module.exports =  _logger;
-

--- a/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/geometry-filter-spatial-reference.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const { normalizeArray } = require('./helpers');
 const normalizeSpatialReference = require('./spatial-reference');
 
@@ -16,7 +16,7 @@ function normalizeGeometryFilterSpatialReference (options = {}) {
   const spatialReference = normalizeSpatialReference(geometryEnvelopeSpatialReference || options.inSR);
 
   if (!spatialReference) {
-    logger.debug('geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
+    logManager.logger.debug('geometry filter spatial reference unknown. Defaulting to EPSG:4326.');
   }
   return spatialReference || { wkid: 4326 };
 }

--- a/packages/winnow/src/normalize-query-options/id-field.js
+++ b/packages/winnow/src/normalize-query-options/id-field.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 /**
  * Ensure idField is set if metadata doesn't have a value but a field named OBJECTID is present
  * @param {object} metadata
@@ -9,7 +9,7 @@ function normalizeIdField (options, features = []) {
   const idField = extractIdField(metadata, features[0]);
 
   if (shouldWarnIdFieldIsMissingFromData(idField, features)) {
-    logger.debug('requested provider has "idField" assignment, but this property is not found in properties of all features.');
+    logManager.logger.debug('requested provider has "idField" assignment, but this property is not found in properties of all features.');
   }
 
   return idField;

--- a/packages/winnow/src/normalize-query-options/limit.js
+++ b/packages/winnow/src/normalize-query-options/limit.js
@@ -1,4 +1,4 @@
-const { logger } = require('../logger');
+const logManager = require('../logger');
 
 /**
  * Normalize the limit option; defaults to undefined
@@ -9,7 +9,7 @@ function normalizeLimit(options) {
   const limit = getLimitFromOptions(options);
 
   if (limit !== undefined && !Number.isInteger(limit)) {
-    logger.debug('"limit" option is not an integer; skipping');
+    logManager.logger.debug('"limit" option is not an integer; skipping');
     return;
   }
   // If there is a limit, add 1 to it so we can later calculate a limitExceeded. The result set will be resized accordingly, post SQL

--- a/packages/winnow/src/normalize-query-options/output-data-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/output-data-spatial-reference.js
@@ -1,6 +1,6 @@
 const normalizeSpatialReference = require('./spatial-reference');
 const { getCollectionCrs } = require('./helpers');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 
 function normalizeOutputDataSpatialReference (options = {}) {
   const {
@@ -20,7 +20,7 @@ function normalizeOutputDataSpatialReference (options = {}) {
   const spatialReference = normalizeSpatialReference(outputSpatialReference);
 
   if (!spatialReference) {
-    logger.debug(`spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
+    logManager.logger.debug(`spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
     // @TODO: throw error
   }
 

--- a/packages/winnow/src/normalize-query-options/source-data-spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/source-data-spatial-reference.js
@@ -1,6 +1,6 @@
 const normalizeSpatialReference = require('./spatial-reference');
 const { getCollectionCrs } = require('./helpers');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 
 function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection } = {}) {
   const sourceDataSpatialReference = inputCrs || sourceSR || getCollectionCrs(collection);
@@ -9,7 +9,7 @@ function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection }
   const spatialReference = normalizeSpatialReference(sourceDataSpatialReference);
 
   if (!spatialReference) {
-    logger.debug(`spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
+    logManager.logger.debug(`spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`);
     // @TODO: throw error?
   }
   return spatialReference || { wkid: 4326 };

--- a/packages/winnow/src/normalize-query-options/spatial-reference.js
+++ b/packages/winnow/src/normalize-query-options/spatial-reference.js
@@ -1,7 +1,7 @@
 const esriProjCodes = require('@esri/proj-codes');
 const Joi = require('joi');
 const wktParser = require('wkt-parser');
-const { logger } = require('../logger');
+const logManager = require('../logger');
 const PROJ4_WKIDS = [4326, 4269, 3857, 3785, 900913, 102113];
 const wktLookup = new Map();
 const schema = Joi.alternatives(
@@ -21,7 +21,7 @@ function normalizeSpatialReference (input) {
   const { error } = schema.validate(input);
 
   if (error) {
-    logger.debug(`${input} is not a valid spatial reference; defaulting to none`);
+    logManager.logger.debug(`${input} is not a valid spatial reference; defaulting to none`);
     // Todo: throw error
     return;
   }
@@ -93,7 +93,7 @@ function esriWktLookup (wkid) {
 
   if (!result) {
     // Todo - throw error
-    logger.debug(`An unknown spatial reference was detected: ${wkid}; defaulting to none`);
+    logManager.logger.debug(`An unknown spatial reference was detected: ${wkid}; defaulting to none`);
     return;
   }
 
@@ -114,7 +114,7 @@ function convertStringToSpatialReference (wkt) {
       wkid: wkid ? Number(wkid) : undefined
     };
   } catch (err) {
-    logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
+    logManager.logger.debug(`An un-parseable WKT spatial reference was detected: ${wkt}`);
     // Todo: throw error
   }
 }


### PR DESCRIPTION
Default loggers in FeatureServer and Winnow are overridden by Koop logger when FeatureServer is registered.  As a result, the logger needs to accessed at request time, because in such cases the logger instance (with associated log level, formatting, etc) has changed. 