### PR TITLE
fix: allow empty strings in geoservices defaults

### DIFF
--- a/.changeset/mighty-ravens-bathe.md
+++ b/.changeset/mighty-ravens-bathe.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- all null or empty strings as overrides for description, service description, copyrightText

--- a/.changeset/mighty-ravens-bathe.md
+++ b/.changeset/mighty-ravens-bathe.md
@@ -2,4 +2,4 @@
 '@koopjs/featureserver': patch
 ---
 
-- all null or empty strings as overrides for description, service description, copyrightText
+- allow null or empty strings as overrides for description, service description, copyrightText

--- a/packages/featureserver/src/metadata-defaults.js
+++ b/packages/featureserver/src/metadata-defaults.js
@@ -57,17 +57,17 @@ const overridablesSchema = joi.object({
   fullVersion: joi.string(),
   maxRecordCount: joi.number(),
   server: joi.object({
-    serviceDescription: joi.string(),
-    description: joi.string(),
-    copyrightText: joi.string(),
+    serviceDescription: joi.string().allow(null, ''),
+    description: joi.string().allow(null, ''),
+    copyrightText: joi.string().allow(null, ''),
     hasStaticData: joi.boolean(),
     spatialReference: spatialReferenceSchema,
     initialExtent: esriExtentSchema,
     fullExtent: esriExtentSchema,
   }),
   layer: joi.object({
-    description: joi.string(),
-    copyrightText: joi.string(),
+    description: joi.string().allow(null, ''),
+    copyrightText: joi.string().allow(null, ''),
     extent: esriExtentSchema,
   }),
 });


### PR DESCRIPTION
This PR allows null values or empty strings as overrides for the geoservicesDefaults options: `description`, `serviceDescription`, `copyrightText`.