### PR TITLE
Check callback type 

### DIFF
--- a/.changeset/modern-pets-press.md
+++ b/.changeset/modern-pets-press.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- add type check to callback sanitization

--- a/packages/featureserver/src/response-handler.js
+++ b/packages/featureserver/src/response-handler.js
@@ -1,5 +1,5 @@
 module.exports = function responseHandler (req, res, statusCode, payload) {
-  if (req.query.callback) {
+  if (typeof req.query.callback === 'string') {
     let sanitizedCallback = req.query.callback.replace(/[^\w\d\.\(\)\[\]]/g, '') // eslint-disable-line
     res.set('Content-Type', 'application/javascript');
     res.status(statusCode);


### PR DESCRIPTION
The `callback` query param gets sanitized when present, but currently there is no type checking.  This means there would be a request time-error if the value's type was not a string.

The PR adds type-checking.