### PR TITLE
feat: allow strings as unique-identifier

### DIFF
--- a/.changeset/smooth-baboons-bathe.md
+++ b/.changeset/smooth-baboons-bathe.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/winnow': minor
+---
+
+- allow string attributes as objectIds parameter for filtering

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
@@ -10,10 +10,8 @@ module.exports = function transformToEsriProperties (properties, geometry, delim
 
   if (requiresObjectId && !idField) {
     properties = injectObjectId({ properties, geometry });
-  }
-
-  if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
-    logManager.logger.debug(`OBJECTIDs created from provider's "idField" (${idField}: ${properties[idField]}) are not integers from 0 to 2147483647`);
+  } else if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
+    logManager.logger.debug(`Unique-identifier (\`${idField}\`) has a value (${properties[idField]}) that is not a valid integer (0 to 2147483647); this may cause problems in some clients.`);
   }
 
   return transformProperties(properties, dateFields);

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
@@ -22,7 +22,7 @@ test('toEsriAttributes, requires idField, properties contain it, but logs debug 
     '../../log-manager': {
       logger: {
         debug: (message) => {
-          t.equals(message, 'OBJECTIDs created from provider\'s "idField" (OBJECTID: 11111) are not integers from 0 to 2147483647');
+          t.equals(message, 'Unique-identifier (`OBJECTID`) has a value (11111) that is not a valid integer (0 to 2147483647); this may cause problems in some clients.');
         }
       }
     }

--- a/packages/winnow/src/normalize-query-options/object-ids.js
+++ b/packages/winnow/src/normalize-query-options/object-ids.js
@@ -21,9 +21,9 @@ function normalizeIds(objectIds) {
 }
 
 function parseId(id) {
-  const castedId = Number(id);
+  const numericId = Number(id);
 
-  return Number.isInteger(castedId) ? castedId : id;
+  return Number.isInteger(numericId) ? numericId : id;
 }
 
 module.exports = normalizeIds;

--- a/packages/winnow/src/normalize-query-options/object-ids.js
+++ b/packages/winnow/src/normalize-query-options/object-ids.js
@@ -21,13 +21,9 @@ function normalizeIds(objectIds) {
 }
 
 function parseId(id) {
-  const objectId = Number(id);
+  const castedId = Number(id);
 
-  if (Number.isInteger(objectId)) {
-    return objectId;
-  }
-
-  throw new InvalidParameterError(`Non-integer objectId: ${id}`);
+  return Number.isInteger(castedId) ? castedId : id;
 }
 
 module.exports = normalizeIds;

--- a/packages/winnow/src/normalize-query-options/object-ids.spec.js
+++ b/packages/winnow/src/normalize-query-options/object-ids.spec.js
@@ -22,6 +22,13 @@ test('normalize objectIds: delimited numeric string', t => {
   t.deepEqual(normalized, [1, 2]);
 });
 
+test('normalize objectIds: delimited strings', t => {
+  t.plan(1);
+
+  const normalized = normalizeObjectIds('abc3ef,xyz123');
+  t.deepEqual(normalized, ['abc3ef','xyz123']);
+});
+
 test('normalize objectIds: integer', t => {
   t.plan(1);
 
@@ -44,18 +51,6 @@ test('normalize objectIds: throw on unsupported data type', t => {
     t.fail('should have thrown');
   } catch (err) {
     t.equals(err.message, 'Invalid objectIds: true');
-    t.equals(err.code, 400);
-  }
-});
-
-test('normalize objectIds: throw on non-integer string', t => {
-  t.plan(2);
-
-  try {
-    normalizeObjectIds('1.4');
-    t.fail('should have thrown');
-  } catch (err) {
-    t.equals(err.message, 'Non-integer objectId: 1.4');
     t.equals(err.code, 400);
   }
 });

--- a/packages/winnow/src/sql-query-builder/where-builder/index.js
+++ b/packages/winnow/src/sql-query-builder/where-builder/index.js
@@ -137,9 +137,13 @@ class WhereBuilder {
   }
 
   #addObjectIdsFilter() {
+    const inValues = this.#options.objectIds.map(val => {
+      return isNaN(val) ? `'${val}'` : val;
+    });
+    
     const objectIdFilter = `${
       this.#options.idField || 'OBJECTID'
-    } IN (${this.#options.objectIds.join(',')})`;
+    } IN (${inValues.join(',')})`;
 
     if (this.#where) {
       this.#where = `${this.#where} AND ${objectIdFilter}`;

--- a/packages/winnow/src/sql-query-builder/where-builder/index.spec.js
+++ b/packages/winnow/src/sql-query-builder/where-builder/index.spec.js
@@ -22,13 +22,22 @@ test('WhereBuilder.create: where param', (t) => {
   t.equals(whereClause, "properties->`color` = 'red'");
 });
 
-test('WhereBuilder.create: objectIds param', (t) => {
+test('WhereBuilder.create: objectIds param, numeric', (t) => {
   t.plan(1);
   const whereClause = WhereBuilder.create({
     objectIds: [1, 2],
     idField: 'OBJECTID'
   });
   t.equals(whereClause, "properties->`OBJECTID` IN (1, 2 )");
+});
+
+test('WhereBuilder.create: objectIds param, string', (t) => {
+  t.plan(1);
+  const whereClause = WhereBuilder.create({
+    objectIds: ['abc', 'xyz'],
+    idField: 'OBJECTID'
+  });
+  t.equals(whereClause, "properties->`OBJECTID` IN ('abc', 'xyz' )");
 });
 
 test('WhereBuilder.create: where param and objectIds param', (t) => {

--- a/packages/winnow/src/sql-query-builder/where-builder/to-json-where.spec.js
+++ b/packages/winnow/src/sql-query-builder/where-builder/to-json-where.spec.js
@@ -87,12 +87,20 @@ test('toJsonWhere: handle function call', (t) => {
   t.equals(whereFragment, "now() = 'test'");
 });
 
-test('toJsonWhere: handle IN list', (t) => {
+test('toJsonWhere: handle IN list of numbers', (t) => {
   t.plan(1);
 
   const whereFragment = translateSqlWhere('foo IN (1,2,3)');
   t.equals(whereFragment, 'properties->`foo` IN (1, 2, 3 )');
 });
+
+test('toJsonWhere: handle IN list of strings', (t) => {
+  t.plan(1);
+
+  const whereFragment = translateSqlWhere(`foo IN ('foo', 'bar')`);
+  t.equals(whereFragment, 'properties->`foo` IN (\'foo\', \'bar\' )');
+});
+
 
 test('toJsonWhere: handle IS NULL', (t) => {
   t.plan(1);

--- a/test/geoservice-client-requests-provider-w-string-id-field.spec.js
+++ b/test/geoservice-client-requests-provider-w-string-id-field.spec.js
@@ -1,0 +1,165 @@
+const Koop = require('@koopjs/koop-core');
+const provider = require('@koopjs/provider-file-geojson');
+const request = require('supertest');
+const {
+  getServerInfo,
+  getLayersInfo,
+  getLayerInfo,
+  getFirst2000,
+  filterByObjectIds,
+  getOutStatistics,
+  paginated,
+  getWithFilter,
+  getAttributeTable,
+} = require('./helpers/client-response-fixtures');
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  silly: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const idUrlParam = 'points-w-metadata-id';
+const IDFIELD = 'id';
+const koop = new Koop({ logLevel: 'error', logger: mockLogger });
+koop.register(provider, { dataDir: './test/provider-data' });
+
+describe('Typical Geoservice Client request sequence: Dataset with defined idField point at string property', () => {
+  let objectIds;
+
+  beforeAll(async () => {
+    const response = await request(koop.server).get(
+      `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?returnIdsOnly=true`,
+    );
+    objectIds = response.body.objectIds;
+  });
+
+  describe('Service inquiry', () => {
+    test('get server info', async () => {
+      try {
+        const response = await request(koop.server).get(
+          `/file-geojson/rest/services/${idUrlParam}/FeatureServer`,
+        );
+        expect(response.status).toBe(200);
+        const serverInfo = response.body;
+        expect(serverInfo).toEqual(getServerInfo(idUrlParam));
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    });
+
+    test('get layers info', async () => {
+      try {
+        const response = await request(koop.server).get(
+          `/file-geojson/rest/services/${idUrlParam}/FeatureServer/layers`,
+        );
+        expect(response.status).toBe(200);
+        const info = response.body;
+        expect(info).toEqual(getLayersInfo(idUrlParam, IDFIELD));
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    });
+  });
+
+  describe('On adding layer to map', () => {
+    test('get layer info', async () => {
+      try {
+        const response = await request(koop.server).get(
+          `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0`,
+        );
+        expect(response.status).toBe(200);
+        const info = response.body;
+        expect(info).toEqual(getLayerInfo(idUrlParam, IDFIELD));
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    });
+
+    test('returnIdsOnly, returnCountOnly', async () => {
+      const response = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&returnIdsOnly=true&returnCountOnly=true&spatialRel=esriSpatialRelIntersects&where=1%3D1`,
+      );
+      expect(response.status).toBe(200);
+      const results = response.body;
+      expect(results).toEqual({ count: 3 });
+    });
+
+    test('get first 2000, only OBJECTIDs, orderBy OBJECTID, convert outSR', async () => {
+      const response = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&resultOffset=0&resultRecordCount=2000&where=1%3D1&orderByFields=${IDFIELD}&outFields=${IDFIELD}&outSR=102100&spatialRel=esriSpatialRelIntersects`,
+      );
+      expect(response.status).toBe(200);
+      const results = response.body;
+      expect(results).toEqual(getFirst2000(IDFIELD, objectIds));
+    });
+  });
+
+  describe('On "identify" operation', () => {
+    test('filter by objectIds, return all outFields (wildcard)', async () => {
+      const identifyResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&objectIds=${objectIds[0]}&outFields=*&outSR=102100&spatialRel=esriSpatialRelIntersects&where=1%3D1`,
+      );
+
+      expect(identifyResponse.body).toEqual(filterByObjectIds(IDFIELD, objectIds));
+    });
+
+    test('filter by objectIds, return all outFields defined by layer info', async () => {
+      const layerInfoResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0`,
+      );
+
+      const fields = layerInfoResponse.body.fields.map((field) => field.name);
+
+      const identifyResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&objectIds=${
+          objectIds[0]
+        }&outFields=${fields.join(
+          ',',
+        )}&outSR=102100&spatialRel=esriSpatialRelIntersects&where=1%3D1`,
+      );
+
+      expect(identifyResponse.body).toEqual(filterByObjectIds(IDFIELD, objectIds));
+    });
+  });
+
+  describe('On "map-filter" operation', () => {
+    test('outStatitics', async () => {
+      const statisticsResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&groupByFieldsForStatistics=category&outFields=*&outStatistics=%5B%7B%22onStatisticField%22%3A%22category%22%2C%22outStatisticFieldName%22%3A%22countOFcategory%22%2C%22statisticType%22%3A%22count%22%7D%5D&spatialRel=esriSpatialRelIntersects&where=1%3D1`,
+      );
+
+      expect(statisticsResponse.body).toEqual(getOutStatistics());
+    });
+
+    test('get features by page, outFields only the filtered attribute ', async () => {
+      const featuresResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&resultOffset=2&resultRecordCount=1&where=1%3D1&orderByFields=${IDFIELD}&outFields=category&outSR=102100&returnGeometry=false&spatialRel=esriSpatialRelIntersects`,
+      );
+
+      expect(featuresResponse.body).toEqual(paginated(IDFIELD));
+    });
+
+    test('reload map after filter application', async () => {
+      const featuresResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&resultOffset=0&resultRecordCount=2000&where=category%20%3D%20%27pinto%27&orderByFields=${IDFIELD}&outFields=category%2C${IDFIELD}&outSR=102100&spatialRel=esriSpatialRelIntersects`,
+      );
+
+      expect(featuresResponse.body).toEqual(getWithFilter(IDFIELD, objectIds));
+    });
+  });
+
+  describe('On open attribute table', () => {
+    test('get first 50 features without geometry', async () => {
+      const featuresResponse = await request(koop.server).get(
+        `/file-geojson/rest/services/${idUrlParam}/FeatureServer/0/query?f=json&&resultOffset=0&resultRecordCount=50&where=1%3D1&orderByFields=&outFields=*&returnGeometry=false&spatialRel=esriSpatialRelIntersects`,
+      );
+
+      expect(featuresResponse.body).toEqual(getAttributeTable(IDFIELD, objectIds));
+    });
+  });
+});

--- a/test/geoservice-query.spec.js
+++ b/test/geoservice-query.spec.js
@@ -132,20 +132,6 @@ describe('koop', () => {
             }
           });
         });
-
-        test('400 error on invalid value', async () => {
-          try {
-            const response = await request(koop.server).get('/file-geojson/rest/services/points-wo-objectid/FeatureServer/0/query?objectIds=1.4');
-            expect(response.status).toBe(200);
-            const { error } = response.body;
-            expect(error.message).toBe('Non-integer objectId: 1.4');
-            expect(error.code).toBe(400);
-            expect(error.details).toEqual(['Non-integer objectId: 1.4']);
-          } catch (error) {
-            console.error(error);
-            throw error;
-          }
-        });
       });
     });
   });

--- a/test/provider-data/points-w-metadata-id-string.geojson
+++ b/test/provider-data/points-w-metadata-id-string.geojson
@@ -1,0 +1,62 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "idField": "id",
+    "fields": [
+        { "name": "timestamp", "type": "Date" },
+        { "name": "id", "type": "Number" },
+        { "name": "label", "type": "String" },
+        { "name": "category", "type": "String" }
+      ]
+    },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aaa",
+        "timestamp": "2023-04-10T16:15:30.000Z",
+        "label": "White Leg",
+        "category": "pinto"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -80,
+          25
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "bbb",
+        "timestamp": "2020-04-12T16:15:30.000Z",
+        "label": "Fireman",
+        "category": "pinto"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120,
+          45
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "ccc",
+        "timestamp": "2015-04-11T16:15:30.000Z",
+        "label": "Workhorse",
+        "category": "draft"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -100,
+          40
+        ]
+      }
+    }
+  ]
+}

--- a/test/provider-data/points-w-metadata-id-string.geojson
+++ b/test/provider-data/points-w-metadata-id-string.geojson
@@ -4,7 +4,7 @@
     "idField": "id",
     "fields": [
         { "name": "timestamp", "type": "Date" },
-        { "name": "id", "type": "Number" },
+        { "name": "id", "type": "String" },
         { "name": "label", "type": "String" },
         { "name": "category", "type": "String" }
       ]


### PR DESCRIPTION
See https://github.com/koopjs/koop/issues/803.

This PR allows string attributes to be used as the  unique-id in Koop Feature Services.