### PR TITLE
fix: log messages for idField and integer range

### DIFF
--- a/.changeset/orange-readers-sip.md
+++ b/.changeset/orange-readers-sip.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/winnow': patch
+---
+
+- alter log message for max safe integer range

--- a/.changeset/rude-frogs-sneeze.md
+++ b/.changeset/rude-frogs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- prevent log message when OBJECTID found in data

--- a/packages/featureserver/src/query/log-warnings.js
+++ b/packages/featureserver/src/query/log-warnings.js
@@ -6,9 +6,11 @@ function logWarnings(geojson, format) {
   const { metadata = {}, features } = geojson;
   const esriFormat = format !== geojson;
 
-  if (esriFormat && !metadata.idField) {
+  const properties = _.get(features, '[0].properties') || _.get(features, '[0].attributes');
+
+  if (esriFormat && !metadata.idField && !properties?.OBJECTID) {
     logManager.logger.debug(
-      'requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.',
+      `provider data has no OBJECTID and has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an integer in range 0 - ${Number.MAX_SAFE_INTEGER}. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.`,
     );
   }
 
@@ -18,10 +20,10 @@ function logWarnings(geojson, format) {
     );
   }
 
-  if (metadata.fields && _.has(features, '[0].properties')) {
-    compareFieldDefintionsToFeature(metadata.fields, features[0].properties);
+  if (metadata.fields && properties) {
+    compareFieldDefintionsToFeature(metadata.fields, properties);
   
-    compareFeatureToFieldDefinitions(features[0].properties, metadata.fields);
+    compareFeatureToFieldDefinitions(properties, metadata.fields);
   }
 }
 

--- a/packages/featureserver/src/query/log-warnings.js
+++ b/packages/featureserver/src/query/log-warnings.js
@@ -8,7 +8,7 @@ function logWarnings(geojson, format) {
 
   const properties = _.get(features, '[0].properties') || _.get(features, '[0].attributes');
 
-  if (esriFormat && !metadata.idField && !properties?.OBJECTID) {
+  if (esriFormat && !metadata.idField && properties?.OBJECTID === undefined) {
     logManager.logger.debug(
       `provider data has no OBJECTID and has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an integer in range 0 - ${Number.MAX_SAFE_INTEGER}. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.`,
     );

--- a/packages/featureserver/src/query/log-warnings.spec.js
+++ b/packages/featureserver/src/query/log-warnings.spec.js
@@ -21,7 +21,7 @@ describe('logWarnings', () => {
     logWarnings({});
     loggerSpy.callCount.should.equal(1);
     loggerSpy.firstCall.args.should.deepEqual([
-      'requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.',
+      `provider data has no OBJECTID and has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an integer in range 0 - ${Number.MAX_SAFE_INTEGER}. An OBJECTID field will be auto-generated in the absence of an "idField" assignment.`,
     ]);
   });
 

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.js
@@ -11,7 +11,7 @@ module.exports = function transformToEsriProperties (properties, geometry, delim
   if (requiresObjectId && !idField) {
     properties = injectObjectId({ properties, geometry });
   } else if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
-    logManager.logger.debug(`Unique-identifier (\`${idField}\`) has a value (${properties[idField]}) that is not a valid integer (0 to 2147483647); this may cause problems in some clients.`);
+    logManager.logger.debug(`Unique-identifier (\`${idField}\`) has a value (${properties[idField]}) that is not a valid integer (0 to ${Number.MAX_SAFE_INTEGER}); this may cause problems in some clients.`);
   }
 
   return transformProperties(properties, dateFields);
@@ -27,7 +27,7 @@ function injectObjectId (feature) {
 }
 
 function shouldLogIdFieldWarning (idFieldValue) {
-  return idFieldValue && (!Number.isInteger(idFieldValue) || idFieldValue > 2147483647);
+  return idFieldValue && (!Number.isInteger(idFieldValue) || idFieldValue > Number.MAX_SAFE_INTEGER);
 }
 
 function transformProperties (properties, dateFields) {

--- a/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
+++ b/packages/winnow/src/filter-and-transform/transforms/to-esri-attributes.spec.js
@@ -22,14 +22,14 @@ test('toEsriAttributes, requires idField, properties contain it, but logs debug 
     '../../log-manager': {
       logger: {
         debug: (message) => {
-          t.equals(message, 'Unique-identifier (`OBJECTID`) has a value (11111) that is not a valid integer (0 to 2147483647); this may cause problems in some clients.');
+          t.equals(message, `Unique-identifier (\`OBJECTID\`) has a value (abc) that is not a valid integer (0 to ${Number.MAX_SAFE_INTEGER}); this may cause problems in some clients.`);
         }
       }
     }
   });
   // (properties, geometry, dateFields, requiresObjectId, idField)
-  const result = toEsriAttributes({ foo: 'bar', OBJECTID: '11111' }, { coordinates: [-118, 34] }, '', 'true', 'OBJECTID');
-  t.deepEquals(result, { foo: 'bar', OBJECTID: '11111' });
+  const result = toEsriAttributes({ foo: 'bar', OBJECTID: 'abc' }, { coordinates: [-118, 34] }, '', 'true', 'OBJECTID');
+  t.deepEquals(result, { foo: 'bar', OBJECTID: 'abc' });
   t.end();
 });
 

--- a/test/geoservice-query.spec.js
+++ b/test/geoservice-query.spec.js
@@ -119,7 +119,6 @@ describe('koop', () => {
 
           test('handles delimited values', async () => {
             try {
-              const url = `/file-geojson/rest/services/points-wo-objectid/FeatureServer/0/query?objectIds=${objectIds[1]},${objectIds[2]}`;
               const response = await request(koop.server).get(`/file-geojson/rest/services/points-wo-objectid/FeatureServer/0/query?objectIds=${objectIds[1]},${objectIds[2]}`);
               expect(response.status).toBe(200);
               const { features } = response.body;


### PR DESCRIPTION
- fix messaging about "no idField" when OBJECTID is already a property in the GeoJSON; this message should be omitted under these conditions
- when messaging about the range of the OBJECTID, it should be the MAX_SAFE_INTEGER value