### PR TITLE
test: simplify e2e params

### DIFF
--- a/test/geoservice-client-requests-no-geom.spec.js
+++ b/test/geoservice-client-requests-no-geom.spec.js
@@ -1,11 +1,9 @@
 const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 const request = require('supertest');
-const VERSION = process.env.VERSION ? Number(process.env.VERSION) : 11.1;
-const FULL_VERSION = process.env.FULL_VERSION || '11.1.0';
-const COPYRIGHT_TEXT =
-  process.env.COPYRIGHT_TEXT ||
-  'Copyright information varies by provider. For more information please contact the source of this data.';
+const VERSION = 11.1;
+const FULL_VERSION = '11.1.0';
+const COPYRIGHT_TEXT = 'Copyright information varies by provider. For more information please contact the source of this data.';
 
 const mockLogger = {
   debug: () => {},
@@ -105,8 +103,7 @@ describe('Typical Geoservice Client request sequence: Dataset with no geometry',
               name: 'no-geom-w-objectid.geojson',
               type: 'Table',
               description: 'GeoJSON from no-geom-w-objectid.geojson',
-              copyrightText:
-                'Copyright information varies by provider. For more information please contact the source of this data.',
+              copyrightText: COPYRIGHT_TEXT,
               parentLayer: null,
               subLayers: null,
               defaultVisibility: true,

--- a/test/geoservice-defaults.spec.js
+++ b/test/geoservice-defaults.spec.js
@@ -1,9 +1,11 @@
 const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 const request = require('supertest');
+const VERSION = 11.2;
+const FULL_VERSION = '11.2.0';
 
 describe('Geoservices defaults settings', () => {
-  const koop = new Koop({ logLevel: 'error', geoservicesDefaults: { currentVersion: 11.2, fullVersion: '11.2.0' } });
+  const koop = new Koop({ logLevel: 'error', geoservicesDefaults: { currentVersion: VERSION, fullVersion: FULL_VERSION } });
   koop.register(provider, { dataDir: './test/provider-data' });
   test('should return server metadata with expected version', async () => {
     try {

--- a/test/helpers/client-response-fixtures.js
+++ b/test/helpers/client-response-fixtures.js
@@ -1,8 +1,6 @@
-const VERSION = process.env.VERSION ? Number(process.env.VERSION) : 11.1;
-const FULL_VERSION = process.env.FULL_VERSION || '11.1.0';
-const COPYRIGHT_TEXT =
-  process.env.COPYRIGHT_TEXT ||
-  'Copyright information varies by provider. For more information please contact the source of this data.';
+const VERSION =  11.1;
+const FULL_VERSION = '11.1.0';
+const COPYRIGHT_TEXT = 'Copyright information varies by provider. For more information please contact the source of this data.';
 
 function getServerInfo(id) {
   return {


### PR DESCRIPTION
- revert params by process.env, but leave `const` defs