### PR TITLE
fix: convert YYYY-MM-DD hh:mm:ss.s to epoch time

### DIFF
--- a/.changeset/friendly-waves-wink.md
+++ b/.changeset/friendly-waves-wink.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': patch
+---
+
+- handle SQL date types in field defs

--- a/packages/featureserver/coverage-unit.svg
+++ b/packages/featureserver/coverage-unit.svg
@@ -1,20 +1,20 @@
-<svg width="107.3" height="20" viewBox="0 0 1073 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 93.5%">
-  <title>coverage: 93.5%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 93.51%">
+  <title>coverage: 93.51%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="m"><rect width="1073" height="200" rx="30" fill="#FFF"/></mask>
+  <mask id="m"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="603" height="200" fill="#555"/>
-    <rect width="470" height="200" fill="#97c40f" x="603"/>
-    <rect width="1073" height="200" fill="url(#a)"/>
+    <rect width="540" height="200" fill="#97c40f" x="603"/>
+    <rect width="1143" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="370" fill="#000" opacity="0.25">93.5%</text>
-    <text x="648" y="138" textLength="370">93.5%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">93.51%</text>
+    <text x="648" y="138" textLength="440">93.51%</text>
   </g>
   
 </svg>

--- a/packages/featureserver/package.json
+++ b/packages/featureserver/package.json
@@ -35,6 +35,7 @@
     "iso-datestring-validator": "^2.2.2",
     "joi": "^17.10.2",
     "lodash": "^4.17.21",
+    "postgres-date": "^2.1.0",
     "wkt-parser": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/featureserver/src/helpers/data-type-utils.js
+++ b/packages/featureserver/src/helpers/data-type-utils.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 const {
   isValidISODateString,
-  isValidDate
+  isValidDate,
 } = require('iso-datestring-validator');
+const dateTimeParser = require('postgres-date');
 
 const PROBLEMATIC_STRING_SYMBOLS = ['(', '[', '*', '+', '\\', '?'];
 
@@ -24,7 +25,7 @@ function isDate (value) {
     return false;
   }
 
-  return (value instanceof Date || (typeof value === 'string') && (isValidDate(value) || isValidISODateString(value)));
+  return (value instanceof Date || (typeof value === 'string') && !!(dateTimeParser(value) || isValidDate(value) || isValidISODateString(value)));
 }
 
 module.exports = {

--- a/packages/featureserver/src/helpers/data-type-utils.spec.js
+++ b/packages/featureserver/src/helpers/data-type-utils.spec.js
@@ -36,7 +36,19 @@ describe('isDate', () => {
   });
 
   it('should return true for ISO string', () => {
-    getDataTypeFromValue(new Date().toISOString()).should.equal('Date');
+    isDate(new Date().toISOString()).should.equal(true);
+  });
+
+  it('should return true for SQL Date', () => {
+    isDate('2020-10-01').should.equal(true);
+  });
+
+  it('should return true for SQL Datetime', () => {
+    isDate('2020-10-01 10:31:45.000').should.equal(true);
+  });
+
+  it('should return false for YYYY/MM/DD', () => {
+    isDate('2020/10/01').should.equal(false);
   });
 
   it('should return false for number', () => {

--- a/packages/winnow/coverage.svg
+++ b/packages/winnow/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 98.35%">
-  <title>coverage: 98.35%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 98.34%">
+  <title>coverage: 98.34%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">98.35%</text>
-    <text x="648" y="138" textLength="440">98.35%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">98.34%</text>
+    <text x="648" y="138" textLength="440">98.34%</text>
   </g>
   
 </svg>


### PR DESCRIPTION
Convert of YYYY-MM-DD hh:mm:ss.s to epoch time.  Labeling and releasing as a patch, given it was likely a regression from functionality in pre-monorepo Koop.