### PR TITLE
feat: allow no-callback getData and model.pull

### DIFF
--- a/.changeset/afraid-hornets-sleep.md
+++ b/.changeset/afraid-hornets-sleep.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': minor
+---
+
+- allow model getData, getLayer, and getCatalog methods to be used without a callback

--- a/.changeset/six-ants-laugh.md
+++ b/.changeset/six-ants-laugh.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/output-geoservices': minor
+---
+
+- use no-callback model.pull form

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,11 +2,15 @@ const Koop = require('@koopjs/koop-core');
 const provider = require('@koopjs/provider-file-geojson');
 const koop = new Koop({ logLevel: 'debug' });
 
+const p = require('../test/helpers/provider-async-no-callback');
+const o = require('../test/helpers/output-pull-with-callback')
 // const auth = require('@koopjs/auth-direct-file')(
 //   'pass-in-your-secret',
 //   `${__dirname}/user-store.json`
 // );
 
 // koop.register(auth);
+koop.register(o)
+koop.register(p)
 koop.register(provider, { dataDir: './demo/provider-data'});
 koop.server.listen(process.env.PORT || 8080);

--- a/packages/core/src/data-provider/index.spec.js
+++ b/packages/core/src/data-provider/index.spec.js
@@ -13,11 +13,11 @@ class MockProviderPluginController {
 }
 
 class MockModel {
-  getData (req, callback) {
-    callback(null, {
+  async getData () {
+    return {
       type: 'FeatureCollection',
       features: []
-    });
+    };
   }
 }
 

--- a/packages/core/src/index.spec.js
+++ b/packages/core/src/index.spec.js
@@ -57,11 +57,11 @@ class MockProviderPluginController {
 }
 
 class MockModel {
-  getData (req, callback) {
-    callback(null, {
+  async getData () {
+    return {
       type: 'FeatureCollection',
       features: []
-    });
+    };
   }
 }
 

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -1,4 +1,3 @@
-const { promisify } = require('util');
 const FeatureServer = require('@koopjs/featureserver');
 const Logger = require('@koopjs/logger');
 let logger = new Logger();
@@ -42,7 +41,6 @@ const authorizationError = {
 class GeoServices {
   #useHttpForTokenUrl = false;
   #authInfo;
-  #pullData;
   #logger;
 
   static type = 'output';
@@ -92,7 +90,6 @@ class GeoServices {
 
   constructor(model, options = {}) {
     this.model = model;
-    this.#pullData = promisify(this.model.pull).bind(this.model);
     this.#logger = options.logger || logger;
     this.#authInfo = options.authInfo || {
       isTokenBasedSecurity: true,
@@ -129,7 +126,7 @@ class GeoServices {
 
   async generalHandler(req, res) {
     try {
-      const data = await this.#pullData(req);
+      const data = await this.model.pull(req);
       return FeatureServer.route(req, res, data);
     } catch (error) {
       this.#logger.error(error);

--- a/test/geoservice-client-requests-no-geom.spec.js
+++ b/test/geoservice-client-requests-no-geom.spec.js
@@ -671,5 +671,4 @@ describe('Typical Geoservice Client request sequence: Dataset with no geometry',
       });
     });
   });
-  console.log(process.env.VERSION);
 });

--- a/test/helpers/output-pull-with-callback.js
+++ b/test/helpers/output-pull-with-callback.js
@@ -1,0 +1,21 @@
+class Output {
+  static type = 'output';
+  static version = '0.0.1';
+  static name = 'output-using-pull-callback';
+  static routes = [    {
+    path: '$namespace/output-path',
+    methods: ['get', 'post'],
+    handler: 'handler',
+  },];
+
+  handler (req, res, next) {
+    this.model.pull(req, (err, data) => {
+      if(err) {
+        return next(err);
+      }
+      res.status(200).json(data);
+    });
+  }
+}
+
+module.exports = Output;

--- a/test/helpers/provider-async-no-callback.js
+++ b/test/helpers/provider-async-no-callback.js
@@ -1,0 +1,26 @@
+class Model {
+  async getData() {
+    return {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [-104.01, 39.94],
+          },
+        },
+      ],
+    };
+  }
+}
+
+module.exports = {
+  type: 'provider',
+  name: 'async-no-callback',
+  hosts: false,
+  disableIdParam: true,
+  Model,
+  version: '0.0.1',
+};

--- a/test/helpers/provider-async-with-callback.js
+++ b/test/helpers/provider-async-with-callback.js
@@ -1,0 +1,26 @@
+class Model {
+  async getData(req, callback) {
+    return callback(null, {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [-104.01, 39.94],
+          },
+        },
+      ],
+    });
+  }
+}
+
+module.exports = {
+  type: 'provider',
+  name: 'async-with-callback',
+  hosts: false,
+  disableIdParam: true,
+  Model,
+  version: '0.0.1',
+};

--- a/test/helpers/provider-callback.js
+++ b/test/helpers/provider-callback.js
@@ -1,0 +1,26 @@
+class Model {
+  getData(req, callback) {
+    return callback(null, {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [-104.01, 39.94],
+          },
+        },
+      ],
+    });
+  }
+}
+
+module.exports = {
+  type: 'provider',
+  name: 'with-callback',
+  hosts: false,
+  disableIdParam: true,
+  Model,
+  version: '0.0.1',
+};

--- a/test/model-pull-signatures.spec.js
+++ b/test/model-pull-signatures.spec.js
@@ -1,0 +1,73 @@
+const Koop = require('@koopjs/koop-core');
+const noCallbackProvider = require('./helpers/provider-async-no-callback');
+const asyncCallbackProvider = require('./helpers/provider-async-with-callback');
+const callbackProvider = require('./helpers/provider-callback');
+const request = require('supertest');
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  silly: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe('test different provider getData forms', () => {
+  const koop = new Koop({ logLevel: 'error', logger: mockLogger });
+  koop.register(noCallbackProvider);
+  koop.register(asyncCallbackProvider);
+  koop.register(callbackProvider);
+
+  test('should return data from provider with async, no-callback getData method', async () => {
+    try {
+      const response = await request(koop.server).get(
+        '/async-no-callback/rest/services/FeatureServer/0/query',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.features).toEqual([
+        {
+          attributes: { OBJECTID: 554348191 },
+          geometry: { x: -104.01, y: 39.94 },
+        },
+      ]);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  });
+
+  test('should return data from provider with async, callback getData method', async () => {
+    try {
+      const response = await request(koop.server).get(
+        '/async-with-callback/rest/services/FeatureServer/0/query',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.features).toEqual([
+        {
+          attributes: { OBJECTID: 554348191 },
+          geometry: { x: -104.01, y: 39.94 },
+        },
+      ]);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  });
+
+  test('should return data from provider with callback getData method', async () => {
+    try {
+      const response = await request(koop.server).get(
+        '/with-callback/rest/services/FeatureServer/0/query',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.features).toEqual([
+        {
+          attributes: { OBJECTID: 554348191 },
+          geometry: { x: -104.01, y: 39.94 },
+        },
+      ]);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  });
+});

--- a/test/output-pull-invocations.spec.js
+++ b/test/output-pull-invocations.spec.js
@@ -1,0 +1,40 @@
+const Koop = require('@koopjs/koop-core');
+const noCallbackProvider = require('./helpers/provider-async-no-callback');
+const output = require('./helpers/output-pull-with-callback');
+
+const request = require('supertest');
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  silly: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe('test output using model.pull with callback arg', () => {
+  const koop = new Koop({ logLevel: 'error', logger: mockLogger });
+  koop.register(output);
+  koop.register(noCallbackProvider);
+
+  test('should return data', async () => {
+    try {
+      const response = await request(koop.server).get(
+        '/async-no-callback/output-path',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        features: [
+          {
+            geometry: { coordinates: [-104.01, 39.94], type: 'Point' },
+            properties: {},
+            type: 'Feature',
+          },
+        ],
+        type: 'FeatureCollection',
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  });
+});


### PR DESCRIPTION
Up until now, provider development required a `getData` method that took a `callback` function as its second (last) argument.  This forced developers to manage responses and errors through the callback function.  This PR allows `getData` to be a simple `async` function with a single `req` argument that returns GeoJSON.  Errors can be directly thrown.

Similarly, output-plugins have had to use the callback argument when invoking the `model.pull` method.  It can now be used as a promise, without the callback argument.

Note that Koop is still fully compatible with providers and outputs that leverage the callback pattern.