### PR TITLE
feat: pass logger into cache plugin constructor

### DIFF
--- a/.changeset/beige-lemons-beg.md
+++ b/.changeset/beige-lemons-beg.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': minor
+---
+
+- pass logger into cache-plugin constructor

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -102,7 +102,7 @@ class Koop extends Events {
   }
 
   #registerCache(Cache, options) {
-    this.cache = new Cache(options);
+    this.cache = new Cache({ logger: options?.logger || this.log, options });
     this.log.info(`registered cache: ${Cache.name} v${Cache.version}`);
   }
   


### PR DESCRIPTION
This PR passes a logger (either the cache registration option or the koop instance logger) in the cache plugin constructor.