### PR TITLE
Quantization mode

### DIFF
--- a/.changeset/eleven-games-cross.md
+++ b/.changeset/eleven-games-cross.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/featureserver": patch
+---
+
+Fix schema for quantizationParameter

--- a/packages/featureserver/src/query/validate-query-request-parameters.js
+++ b/packages/featureserver/src/query/validate-query-request-parameters.js
@@ -16,7 +16,8 @@ const esriExtentSchema = joi.object({
 const quantizationParametersSchema = joi.object({
   originPosition: joi.string().optional(),
   tolerance: joi.number().optional(),
-  extent: esriExtentSchema.optional()
+  extent: esriExtentSchema.optional(),
+  mode: joi.string().optional(),
 });
 
 


### PR DESCRIPTION
Fixes a bug in Esri's AGOL Map Viewer where the .pbf tiles will not load due to the request coming with a quantizationParameter containing "mode".