### PR TITLE
Handle "where" param with +

### DIFF
--- a/.changeset/three-actors-try.md
+++ b/.changeset/three-actors-try.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/featureserver": patch
+---
+
+- allow + as whitespace equivalent in where param

--- a/packages/featureserver/coverage-unit.svg
+++ b/packages/featureserver/coverage-unit.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.93%">
-  <title>coverage: 94.93%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.98%">
+  <title>coverage: 94.98%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.93%</text>
-    <text x="648" y="138" textLength="440">94.93%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.98%</text>
+    <text x="648" y="138" textLength="440">94.98%</text>
   </g>
   
 </svg>

--- a/test/geoservice-query.spec.js
+++ b/test/geoservice-query.spec.js
@@ -132,6 +132,20 @@ describe('koop', () => {
           });
         });
       });
+
+      describe('where', () => {
+        test('handle query with "+" as whitespace', async () => {
+          try {
+            const response = await request(koop.server).get('/file-geojson/rest/services/points-w-objectid/FeatureServer/0/query?WHERE=label+is+not+null');
+            expect(response.status).toBe(200);
+            const { features } = response.body;
+            expect(features.length).toBe(3);
+          } catch (error) {
+            console.error(error);
+            throw error;
+          }
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
GeoServices API specification allows a `where` that uses `+` as a placeholder for whitespace. So something like this is valid:

`where=Foo+IS+NOT+NULL`

The current release of Koop rejects `where` params that are constructed with the `+` delimiter.  This PR patches this limitation.