### PR TITLE
fix: allow proper encoding of string OIDs in PBF format

### DIFF
--- a/.changeset/lazy-wombats-relate.md
+++ b/.changeset/lazy-wombats-relate.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/featureserver": patch
+---
+
+- allow proper PBF encoding of string OID values

--- a/demo/provider-data/points-w-metadata-id-string.geojson
+++ b/demo/provider-data/points-w-metadata-id-string.geojson
@@ -1,0 +1,62 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "idField": "id",
+    "fields": [
+        { "name": "timestamp", "type": "Date" },
+        { "name": "id", "type": "String" },
+        { "name": "label", "type": "String" },
+        { "name": "category", "type": "String" }
+      ]
+    },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aaa",
+        "timestamp": "2023-04-10T16:15:30.000Z",
+        "label": "White Leg",
+        "category": "pinto"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -80,
+          25
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "bbb",
+        "timestamp": "2020-04-12T16:15:30.000Z",
+        "label": "Fireman",
+        "category": "pinto"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120,
+          45
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "ccc",
+        "timestamp": "2015-04-11T16:15:30.000Z",
+        "label": "Workhorse",
+        "category": "draft"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -100,
+          40
+        ]
+      }
+    }
+  ]
+}

--- a/packages/featureserver/coverage-unit.svg
+++ b/packages/featureserver/coverage-unit.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 95.31%">
-  <title>coverage: 95.31%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 95.34%">
+  <title>coverage: 95.34%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">95.31%</text>
-    <text x="648" y="138" textLength="440">95.31%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">95.34%</text>
+    <text x="648" y="138" textLength="440">95.34%</text>
   </g>
   
 </svg>

--- a/packages/featureserver/coverage.svg
+++ b/packages/featureserver/coverage.svg
@@ -1,5 +1,5 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 98.16%">
-  <title>coverage: 98.16%</title>
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 98.17%">
+  <title>coverage: 98.17%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">98.16%</text>
-    <text x="648" y="138" textLength="440">98.16%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">98.17%</text>
+    <text x="648" y="138" textLength="440">98.17%</text>
   </g>
   
 </svg>

--- a/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.js
+++ b/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.js
@@ -20,12 +20,18 @@ function transformToPbfAttributes(attributes, fieldMap) {
     .orderBy(['name'],['asc'])
     .map(({ name, value }) => {
       const type = fieldMap[name];
-      const pbfType = typeLookup[type];
+      const pbfType = dataTypeLookup(type, value);
       return { [pbfType]: value };
     })
     .value();
 }
 
+function dataTypeLookup(fieldType, value) {
+  if(fieldType === 'esriFieldTypeOID') {
+    return Number.isInteger(value) ? 'uintValue' : 'stringValue';
+  }
+  return typeLookup[fieldType];
+}
 module.exports = {
   transformToPbfAttributes
 };

--- a/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.js
+++ b/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.js
@@ -17,7 +17,7 @@ function transformToPbfAttributes(attributes, fieldMap) {
       name: key,
       value,
     }))
-    .orderBy(['name'],['asc'])
+    .orderBy(['name'], ['asc'])
     .map(({ name, value }) => {
       const type = fieldMap[name];
       const pbfType = dataTypeLookup(type, value);
@@ -27,11 +27,11 @@ function transformToPbfAttributes(attributes, fieldMap) {
 }
 
 function dataTypeLookup(fieldType, value) {
-  if(fieldType === 'esriFieldTypeOID') {
+  if (fieldType === 'esriFieldTypeOID') {
     return Number.isInteger(value) ? 'uintValue' : 'stringValue';
   }
   return typeLookup[fieldType];
 }
 module.exports = {
-  transformToPbfAttributes
+  transformToPbfAttributes,
 };

--- a/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.spec.js
+++ b/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.spec.js
@@ -80,7 +80,7 @@ const attributes = {
 
 describe('transformToPbfAttributes', () => {
   it('should transform Esri JSON to Esri PBF JSON', () => {
-    const result = transformToPbfAttributes(attributes ,fieldMap);
+    const result = transformToPbfAttributes(attributes, fieldMap);
     result.should.deepEqual([
       {
         sint64Value: 1421798400000,
@@ -107,8 +107,10 @@ describe('transformToPbfAttributes', () => {
   });
 
   it('should properly handle OIDs that are strings', () => {
-    
-    const result = transformToPbfAttributes({ ...attributes, FID: 'foo' },fieldMap);
+    const result = transformToPbfAttributes(
+      { ...attributes, FID: 'foo' },
+      fieldMap,
+    );
     result.should.deepEqual([
       {
         sint64Value: 1421798400000,

--- a/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.spec.js
+++ b/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-attributes.spec.js
@@ -105,4 +105,32 @@ describe('transformToPbfAttributes', () => {
       },
     ]);
   });
+
+  it('should properly handle OIDs that are strings', () => {
+    
+    const result = transformToPbfAttributes({ ...attributes, FID: 'foo' },fieldMap);
+    result.should.deepEqual([
+      {
+        sint64Value: 1421798400000,
+      },
+      {
+        stringValue: '30040-085-3001-0126-000',
+      },
+      {
+        stringValue: 'foo',
+      },
+      {
+        stringValue: '9279699f-5ece-4ca6-8a3b-b559da37bc5e',
+      },
+      {
+        sintValue: 46104019,
+      },
+      {
+        doubleValue: 99,
+      },
+      {
+        sintValue: 6,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Koop allows use of strings as OBJECTIDs.  While ArcGIS OBJECTIDs are supposed to be integers, many ArcGIS clients seem to work without issue if OBJECTIDs or FIDs are strings.  Big exception is ArcGIS Pro - it fails with datasets that don't use integers.

The currently released PBF encoder in Koop doesn't properly encode string OBJECTIDs.  This results in 0 values for the OBJECTIDs when decoded by clients.  The PR fixes.