### PR TITLE
fix: handle new files in cov report

### DIFF
--- a/ci/format-branch-coverage-changes.js
+++ b/ci/format-branch-coverage-changes.js
@@ -5,10 +5,14 @@ const coverageSummary = require('../.coverage_json/coverage-summary.json');
 const markdownFilePath = '.branch-coverage-changes.md';
 
 if (!existsSync('.coverage_changes_json/coverage-summary.json')) {
-  writeFileSync(markdownFilePath, `## Coverage Report (change vs master)
+  writeFileSync(
+    markdownFilePath,
+    `## Coverage Report (change vs master)
   No changes.
-  `, 'utf8');
-  return;
+  `,
+    'utf8',
+  );
+  process.exit();
 }
 
 const coverageChangesSummary = require('../.coverage_changes_json/coverage-summary.json');
@@ -21,10 +25,22 @@ const rows = Object.entries(coverageChangesSummary)
     const masterCoverage = coverageSummary[packageFilePath];
     return [
       packageFilePath,
-      formatCovComparison(changesCoverage.statements.pct, masterCoverage.statements.pct),
-      formatCovComparison(changesCoverage.branches.pct, masterCoverage.branches.pct),
-      formatCovComparison(changesCoverage.functions.pct, masterCoverage.functions.pct),
-      formatCovComparison(changesCoverage.lines.pct, masterCoverage.lines.pct)
+      formatCovComparison(
+        changesCoverage.statements.pct,
+        masterCoverage?.statements?.pct || 0,
+      ),
+      formatCovComparison(
+        changesCoverage.branches.pct,
+        masterCoverage?.branches?.pct || 0,
+      ),
+      formatCovComparison(
+        changesCoverage.functions.pct,
+        masterCoverage?.functions?.pct || 0,
+      ),
+      formatCovComparison(
+        changesCoverage.lines.pct,
+        masterCoverage?.lines?.pct || 0,
+      ),
     ];
   });
 


### PR DESCRIPTION
New files throw an undefined error in CI script that generates coverage report for PR.