### PR TITLE
fix: remove arity validation for provider transforms

### DIFF
--- a/.changeset/late-meals-provide.md
+++ b/.changeset/late-meals-provide.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/koop-core": patch
+---
+
+- remove arity validation for transform function options

--- a/packages/core/src/data-provider/index.js
+++ b/packages/core/src/data-provider/index.js
@@ -13,8 +13,8 @@ const providerOptionsSchema = Joi.object({
     .unknown(true)
     .optional(),
   routePrefix: Joi.string().optional(),
-  before: Joi.function().arity(2).optional(),
-  after: Joi.function().arity(3).optional(),
+  before: Joi.function().optional(),
+  after: Joi.function().optional(),
   name: Joi.string().optional(),
   defaultToOutputRoutes: Joi.boolean().optional(),
 }).unknown(true);


### PR DESCRIPTION
Provider registration allows for the `before` and `after` options; these are functions that can be used to transform the incoming request _before_ it arrives at the `getData` method or transform the geojson _after_ it is passed out of the `getData` method.  When originally implemented these methods had to use callback form and they were invalid unless they had two (_before_ function ) and three (_after_ function) arguments.  Callback was the last argument for each of course. However, we now allow the use of `async` and as a result it would be valid if the _before_ function had one arg, and the _after_ had two.  This PR removes argument length validation from these function as it doesn't seem worth the complexity. 