### PR TITLE
output-geoservices fix: handle invalid url

### DIFF
--- a/.changeset/modern-dryers-hang.md
+++ b/.changeset/modern-dryers-hang.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/output-geoservices": patch
+---
+
+- handle MapServer requests with invalid url error

--- a/packages/output-geoservices/src/index.js
+++ b/packages/output-geoservices/src/index.js
@@ -105,7 +105,7 @@ class GeoServices {
     {
       path: '$namespace/rest/services/$providerParams/MapServer*',
       methods: ['get', 'post'],
-      handler: 'generalHandler',
+      handler: 'invalidUrlHandler',
     },
   ];
 
@@ -144,13 +144,11 @@ class GeoServices {
     return false;
   }
 
-  async generalHandler(req, res) {
-    try {
-      const data = await this.model.pull(req);
-      return FeatureServer.route(req, res, data);
-    } catch (error) {
-      this.#errorHandler(error, req, res);
-    }
+  async invalidUrlHandler(req, res) {
+    const error = new Error('Invalid URL');
+    error.code = 400;
+    error.details = ['Invalid URL'];
+    this.#errorHandler(error, req, res);
   }
 
   #errorHandler(error, req, res) {


### PR DESCRIPTION
Recent refactor did not properly handle the `Invalid URL` response required on /MapServer route.