### PR TITLE
fix: remove single vertex rings and paths from quantized geometry

### DIFF
--- a/.changeset/polite-lions-protect.md
+++ b/.changeset/polite-lions-protect.md
@@ -1,0 +1,5 @@
+---
+"@koopjs/featureserver": patch
+---
+
+- remove single vertex rings and paths from quantized geometry

--- a/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-geometry.js
+++ b/packages/featureserver/src/response-handlers/helpers/send-pbf/transform-to-pbf-geometry.js
@@ -146,7 +146,7 @@ function transformRings(rings, transform) {
     result.push(ring);
   }
 
-  return result;
+  return result.filter((ring) => ring.length > 1);
 }
 
 function transformPaths(paths, transform) {
@@ -158,7 +158,7 @@ function transformPaths(paths, transform) {
     result.push(path);
   }
 
-  return result;
+  return result.filter((ring) => ring.length > 1);
 }
 
 module.exports = {


### PR DESCRIPTION
Quanitzation applied to PBF encoding needs to strip out single vertex rings/paths that can occur when quantization scaling occurs at wide extents.  Leaving these single vertex rings/paths results in fault geometry.  See below:

![Screenshot 2024-05-13 at 11 27 04 AM](https://github.com/koopjs/koop/assets/4369192/a9b1fccf-637d-4080-9e56-26e56d972eb0)
