### PR TITLE
fix: adding back support for geojson as an output schema

### DIFF
--- a/.changeset/grumpy-boats-crash.md
+++ b/.changeset/grumpy-boats-crash.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/featureserver': minor
+---
+
+Adding back support for geojson as an output schema

--- a/packages/featureserver/src/query/validate-query-request-parameters.js
+++ b/packages/featureserver/src/query/validate-query-request-parameters.js
@@ -1,7 +1,7 @@
 const joi = require('joi');
 const { sharedQueryParamSchema } = require('../helpers/shared-query-request-param-schema');
 
-const formatSchema = joi.string().valid('json', 'pjson', 'pbf').default('json');
+const formatSchema = joi.string().valid('json', 'pjson', 'pbf', 'geojson').default('json');
 
 const spatialReferenceSchema = joi
   .object({

--- a/packages/featureserver/src/query/validate-query-request-parameters.spec.js
+++ b/packages/featureserver/src/query/validate-query-request-parameters.spec.js
@@ -34,7 +34,7 @@ describe('validate-query-request-parameters', () => {
         });
       } catch (error) {
         error.message.should.deepEqual('Invalid format');
-        error.details.should.deepEqual(['"f" must be one of [json, pjson, pbf]']);
+        error.details.should.deepEqual(['"f" must be one of [json, pjson, pbf, geojson]']);
         error.code.should.equal(400);
       }
     });


### PR DESCRIPTION
FeatureServer should allow outputting geojson as a valid schema.

@rgwozdz 