### PR TITLE
Fixed default Model cache key generation issue

### DIFF
--- a/.changeset/silent-dodos-tie.md
+++ b/.changeset/silent-dodos-tie.md
@@ -1,0 +1,5 @@
+---
+'@koopjs/koop-core': patch
+---
+
+Fixed default cache key generation to support POST requests


### PR DESCRIPTION
#### Support GET & POST requests
The default generator was ignoring variances between `GET` & `POST` methods. This caused `POST` requests to get cached incorrectly. Now, both the request query and body are loaded and merged into a common object and stringified as part of the key generation omitting query params from the url string.  This will make the url be the same between `GET` and `POST` and allow for the parameters to be common when submitted into the hasher function.

#### Larger Hash Keys
I also updated the hasher method to use the larger hash size to help prevent collisions since large datasets can be submitted in as part of the caching data.  Users of the api can submit in large sets of `OBJECTIDS` and Geometry as part of query parameters.  This should help mitigate any cache collisions.

#### New Unit Tests
I added some new unit tests to verify that common `GET` and `POST` requests use the same cache even though the request urls will be different. (ie. `GET` will be in the query string and `POST` will be in the body)