### PR TITLE
docs: document bodyParserLimit option (#624)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,6 +65,17 @@ const options = {
 }
 ```
 
+#### bodyParserLimit (or maximum POST body size)
+Koop configures Express maximum body size to 10mb by default. If you want to decrease or increase that size, you can do so by adding a `bodyParserLimit` value to your Koop config file:
+
+```js
+const options = {
+  bodyParserLimit: '20mb'
+}
+```
+
+> See [Supported units and abbreviations](https://www.npmjs.com/package/bytes#bytesparsestringnumber-value-numbernull).
+
 #### logger
 Koop includes a Winston logger with a console transport by default.  If you have a custom logger that you want to use, you can pass it as an option:
 

--- a/packages/core/src/index.spec.js
+++ b/packages/core/src/index.spec.js
@@ -5,6 +5,11 @@ const DataProvider = require('./data-provider');
 
 const providerConstructorSpy = sinon.spy();
 
+const mockBodyParser = {
+  json: sinon.spy(() => {}),
+  urlencoded: sinon.spy(() => {}),
+};
+
 const mockApp = {
   use: sinon.spy(() => mockApp),
   disable: sinon.spy(() => mockApp),
@@ -44,6 +49,7 @@ const Koop = proxyquire('./', {
   './data-provider': mockDataProviderModule,
   '@koopjs/logger': MockLogger,
   express: mockExpress,
+  'body-parser': mockBodyParser,
 });
 
 class MockProviderPluginController {
@@ -91,6 +97,7 @@ describe('Index tests', function () {
       const koop = new Koop();
       koop.config.should.be.empty();
       mockApp.use.callCount.should.equal(5);
+      mockBodyParser.json.calledWith({ limit: '10000kb' });
     });
 
     it('should instantiate Koop with options', function () {
@@ -108,6 +115,13 @@ describe('Index tests', function () {
       new Koop({ disableCors: true, disableCompression: true });
 
       mockApp.use.callCount.should.equal(3);
+    });
+
+    it('should modify bodyParserLimit', function () {
+      new Koop({ bodyParserLimit: '20mb' });
+
+      mockApp.use.callCount.should.equal(5);
+      mockBodyParser.json.calledWith({ limit: '20mb' });
     });
   });
 


### PR DESCRIPTION
Added documentation for koop option `bodyParserLimit` (for POST maximum body size). Also added some unit tests.